### PR TITLE
Setup for releasing docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+stac
 dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,16 @@ archives:
       windows: Windows
       386: i386
       amd64: x86_64
+dockers:
+  - image_templates:
+      - "ghcr.io/planetlabs/go-stac:{{ .Tag }}"
+      - "ghcr.io/planetlabs/go-stac:v{{ .Major }}"
+    build_flag_templates:
+      - --label=org.opencontainers.image.licenses=MIT
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.url=https://github.com/planetlabs/{{ .ProjectName }}
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM scratch
+ENTRYPOINT ["/stac"]
+COPY stac /


### PR DESCRIPTION
This adds GoReleaser configuration for publishing Docker images for all release tags.