### PR TITLE
Stats command for reporting resource and extension counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-stac
-dist/
+/stac
+/dist/

--- a/cmd/stac/main.go
+++ b/cmd/stac/main.go
@@ -98,6 +98,7 @@ func main() {
 		Description: "Utilities for working with Spatio-Temporal Asset Catalog (STAC) metadata.",
 		Commands: []*cli.Command{
 			validateCommand,
+			statsCommand,
 		},
 	}
 


### PR DESCRIPTION
Initial implementation of a `stac stats` command.  For now, this just reports counts of resource type and extension use.  Example output crawling a catalog:
```json
{
  "catalogs": 9,
  "collections": 5,
  "items": 3341,
  "extensions": {
    "https://stac-extensions.github.io/eo/v1.0.0/schema.json": 29,
    "https://stac-extensions.github.io/label/v1.0.0/schema.json": 1423,
    "https://stac-extensions.github.io/projection/v1.0.0/schema.json": 18,
    "https://stac-extensions.github.io/raster/v1.0.0/schema.json": 3,
    "https://stac-extensions.github.io/raster/v1.1.0/schema.json": 3,
    "https://stac-extensions.github.io/view/v1.0.0/schema.json": 29
  }
}
```