### PR TITLE
Crawl in file or URL mode

### DIFF
--- a/cmd/stac/stats.go
+++ b/cmd/stac/stats.go
@@ -97,12 +97,12 @@ var statsCommand = &cli.Command{
 			return nil
 		}
 
-		c := crawler.NewWithOptions(entryPath, visitor, &crawler.Options{
+		c := crawler.NewWithOptions(visitor, &crawler.Options{
 			Concurrency: ctx.Int(flagConcurrency),
 			Recursion:   crawler.RecursionType(ctx.String(flagRecursion)),
 		})
 
-		err := c.Crawl(context.Background())
+		err := c.Crawl(context.Background(), entryPath)
 		if err != nil {
 			return err
 		}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -126,11 +126,11 @@ func schemaUrl(version string, resourceType crawler.ResourceType) string {
 //
 // The resource can be a path to a local file or a URL.
 func (v *Validator) Validate(ctx context.Context, resource string) error {
-	c := crawler.NewWithOptions(resource, v.validate, &crawler.Options{
+	c := crawler.NewWithOptions(v.validate, &crawler.Options{
 		Concurrency: v.concurrency,
 		Recursion:   v.recursion,
 	})
-	return c.Crawl(ctx)
+	return c.Crawl(ctx, resource)
 }
 
 func (v *Validator) validate(resourceUrl string, resource crawler.Resource) error {


### PR DESCRIPTION
If crawling starts on the filesystem, it stays on the filesystem.  If crawling starts with an http(s) URL, it avoids the filesystem.