### PR TITLE
Add command for printing build information

### DIFF
--- a/cmd/stac/main.go
+++ b/cmd/stac/main.go
@@ -15,6 +15,9 @@ const (
 	flagUrl    = "url"
 	flagOutput = "output"
 
+	// version flags
+	flagVerbose = "verbose"
+
 	// common flags
 	flagEntry       = "entry"
 	flagConcurrency = "concurrency"
@@ -102,6 +105,7 @@ func main() {
 			validateCommand,
 			statsCommand,
 			absoluteLinksCommand,
+			versionCommand,
 		},
 	}
 

--- a/cmd/stac/version.go
+++ b/cmd/stac/version.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	version = "development"
+	commit  = "none"
+	date    = "unknown"
+)
+
+var versionCommand = &cli.Command{
+	Name:        "version",
+	Usage:       "Print build information",
+	Description: "Prints the build information for the executable.",
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    flagVerbose,
+			Usage:   "Include additional metadata with the build version",
+			EnvVars: []string{toEnvVar(flagVerbose)},
+		},
+	},
+	Action: func(ctx *cli.Context) error {
+		if ctx.Bool(flagVerbose) {
+			fmt.Printf("%s %s %s\n", version, commit, date)
+			return nil
+		}
+		fmt.Println(version)
+		return nil
+	},
+}


### PR DESCRIPTION
The `version` command prints build information.

```bash
# stac version
0.4.1-next
```

```bash
# stac version --verbose
0.4.1-next 465323fde66484da8e796b887b02e38878b484ca 2022-04-05T16:02:28Z
```