### PR TITLE
Support substitute schema location

### DIFF
--- a/cmd/stac/main.go
+++ b/cmd/stac/main.go
@@ -11,6 +11,9 @@ import (
 )
 
 const (
+	// validate flags
+	flagSchema = "schema"
+
 	// make-links-absolute flags
 	flagUrl    = "url"
 	flagOutput = "output"

--- a/validator/testdata/cases/v1.0.0/item-custom.json
+++ b/validator/testdata/cases/v1.0.0/item-custom.json
@@ -1,0 +1,20 @@
+{
+  "stac_version": "1.0.0",
+  "type": "Feature",
+  "id": "custom-extension-schema-map",
+  "bbox": [0, 0, 0, 0],
+  "geometry": {
+    "type": "Point",
+    "coordinates": [0, 0]
+  },
+  "properties": {
+    "datetime": "2022-03-22T00:00:00Z",
+    "custom:answer": 42,
+    "custom:word": "soup"
+  },
+  "links": [],
+  "assets": {},
+  "stac_extensions": [
+    "https://stac-extensions.github.io/custom/v1.0.0/schema.json"
+  ]
+}

--- a/validator/testdata/schema/example.com/extensions/custom.json
+++ b/validator/testdata/schema/example.com/extensions/custom.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://stac-extensions.github.io/custom/v1.0.0/schema.json#",
+  "title": "Custom Extension",
+  "description": "STAC Custom Extension for STAC Items.",
+  "oneOf": [
+    {
+      "$comment": "This is the schema for STAC Items.",
+      "allOf": [
+        {
+          "type": "object",
+          "required": [
+            "type",
+            "properties"
+          ],
+          "properties": {
+            "type": {
+              "const": "Feature"
+            },
+            "properties": {
+              "allOf": [
+                {
+                  "anyOf": [
+                    {"required": ["custom:answer"]},
+                    {"required": ["custom:word"]}
+                  ]
+                },
+                {
+                  "$ref": "#/definitions/fields"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/stac_extensions"
+        }
+      ]
+    }
+  ],
+  "definitions": {
+    "stac_extensions": {
+      "type": "object",
+      "required": [
+        "stac_extensions"
+      ],
+      "properties": {
+        "stac_extensions": {
+          "type": "array",
+          "contains": {
+            "contains": {
+              "const": "https://stac-extensions.github.io/custom/v1.0.0/schema.json"
+            }
+          }
+        }
+      }
+    },
+    "fields": {
+      "$comment": "Add your new fields here. Don't require them here, do that above in the item schema.",
+      "type": "object",
+      "properties": {
+        "custom:answer": {
+          "title": "Answer",
+          "type": "number",
+          "minimum": 0,
+          "maximum": 99
+        },
+        "custom:word": {
+          "title": "Word",
+          "type": "string"
+        }
+      },
+      "patternProperties": {
+        "^(?!custom:)": {}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -70,6 +70,20 @@ func (s *Suite) TestValidCases() {
 	}
 }
 
+func (s *Suite) TestSchemaMap() {
+	v := validator.New(&validator.Options{
+		Concurrency: crawler.DefaultOptions.Concurrency,
+		Recursion:   crawler.DefaultOptions.Recursion,
+		SchemaMap: map[string]string{
+			"https://stac-extensions.github.io/custom/v1.0.0/schema.json": "https://example.com//extensions/custom.json",
+		},
+	})
+	ctx := context.Background()
+	resourcePath := path.Join("testdata", "cases", "v1.0.0", "item-custom.json")
+	err := v.Validate(ctx, resourcePath)
+	s.Assert().NoError(err)
+}
+
 func TestSuite(t *testing.T) {
 	suite.Run(t, &Suite{})
 }


### PR DESCRIPTION
The `--schema` flag can be used to provide alternate locations for schema.

```bash
stac validate --entry catalog.json --schema https://stac-extensions.github.io/custom/v1.0.0/schema.json=https://example.com/custom/schema.json
```
