### PR TITLE
Error detail, logging, and exit codes

### DIFF
--- a/cmd/stac/main.go
+++ b/cmd/stac/main.go
@@ -25,7 +25,6 @@ const (
 
 	// common flags
 	flagLogLevel    = "log-level"
-	flagLogFormat   = "log-format"
 	flagEntry       = "entry"
 	flagOutput      = "output"
 	flagConcurrency = "concurrency"
@@ -64,13 +63,8 @@ var (
 	logLevelValues = []string{
 		zap.DebugLevel.String(),
 		zap.InfoLevel.String(),
-		zap.WarnLevel.String(),
 		zap.ErrorLevel.String(),
 	}
-
-	logFormatJSON    = "json"
-	logFormatConsole = "console"
-	logFormatValues  = []string{logFormatJSON, logFormatConsole}
 )
 
 func configureLogger(ctx *cli.Context) (*logr.Logger, func(), error) {
@@ -80,12 +74,13 @@ func configureLogger(ctx *cli.Context) (*logr.Logger, func(), error) {
 	}
 
 	config := &zap.Config{
-		Encoding: ctx.String(flagLogFormat),
+		Encoding: "console",
 		EncoderConfig: zapcore.EncoderConfig{
-			LevelKey:   "level",
-			MessageKey: "message",
-			TimeKey:    "time",
-			EncodeTime: zapcore.ISO8601TimeEncoder,
+			MessageKey:  "message",
+			LevelKey:    "level",
+			EncodeLevel: zapcore.LowercaseColorLevelEncoder,
+			TimeKey:     "time",
+			EncodeTime:  zapcore.RFC3339TimeEncoder,
 		},
 		Level:            level,
 		OutputPaths:      []string{"stderr"},

--- a/cmd/stac/validate.go
+++ b/cmd/stac/validate.go
@@ -48,18 +48,9 @@ var validateCommand = &cli.Command{
 			Usage: fmt.Sprintf("Log level (%s)", strings.Join(logLevelValues, ", ")),
 			Value: &Enum{
 				Values:  logLevelValues,
-				Default: zap.InfoLevel.String(),
+				Default: zap.ErrorLevel.String(),
 			},
 			EnvVars: []string{toEnvVar(flagLogLevel)},
-		},
-		&cli.GenericFlag{
-			Name:  flagLogFormat,
-			Usage: fmt.Sprintf("Log format (%s)", strings.Join(logFormatValues, ", ")),
-			Value: &Enum{
-				Values:  logFormatValues,
-				Default: logFormatConsole,
-			},
-			EnvVars: []string{toEnvVar(flagLogFormat)},
 		},
 	},
 	Action: func(ctx *cli.Context) error {
@@ -71,14 +62,14 @@ var validateCommand = &cli.Command{
 
 		entryPath := ctx.String(flagEntry)
 		if entryPath == "" {
-			return fmt.Errorf("missing --%s", flagEntry)
+			return cli.Exit(fmt.Sprintf("missing --%s", flagEntry), 1)
 		}
 
 		schemaMap := map[string]string{}
 		for _, pair := range ctx.StringSlice(flagSchema) {
 			items := strings.Split(pair, "=")
 			if len(items) != 2 {
-				return fmt.Errorf("invalid --%s value %q", flagSchema, pair)
+				return cli.Exit(fmt.Sprintf("invalid --%s value %q", flagSchema, pair), 1)
 			}
 			schemaMap[items[0]] = items[1]
 		}
@@ -92,9 +83,9 @@ var validateCommand = &cli.Command{
 		err := v.Validate(context.Background(), entryPath)
 		if err != nil {
 			if validationErr, ok := err.(*validator.ValidationError); ok {
-				return fmt.Errorf("%#v\n", validationErr)
+				return cli.Exit(fmt.Sprintf("%#v\n", validationErr), 2)
 			}
-			return fmt.Errorf("validation failed: %s\n", err)
+			return cli.Exit(fmt.Sprintf("validation failed: %s\n", err), 3)
 		}
 		return nil
 	},

--- a/validator/errors.go
+++ b/validator/errors.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"fmt"
 
+	"github.com/planetlabs/go-stac/crawler"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 )
 
@@ -10,16 +11,20 @@ import (
 type ValidationError struct {
 	*jsonschema.ValidationError
 
-	// Resource is the file path or URL to the resource that failed validation.
-	Resource string
+	// Location is the file path or URL to the resource that failed validation.
+	Location string
+
+	// The resource being crawled.
+	Resource crawler.Resource
 }
 
 func (err *ValidationError) GoString() string {
-	return fmt.Sprintf("invalid resource: %s\n%s", err.Resource, err.ValidationError.GoString())
+	return fmt.Sprintf("invalid %s: %s\n%s", err.Resource.Type(), err.Location, err.ValidationError.GoString())
 }
 
-func newValidationError(resource string, err *jsonschema.ValidationError) *ValidationError {
+func newValidationError(location string, resource crawler.Resource, err *jsonschema.ValidationError) *ValidationError {
 	return &ValidationError{
+		Location:        location,
 		Resource:        resource,
 		ValidationError: err,
 	}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -161,7 +161,7 @@ func (v *Validator) Validate(ctx context.Context, resource string) error {
 }
 
 func (v *Validator) validate(resourceUrl string, resource crawler.Resource) error {
-	v.logger.V(1).Info("validating resource", "resource", resourceUrl)
+	v.logger.Info("validating resource", "resource", resourceUrl)
 	version := resource.Version()
 	if version == "" {
 		return errors.New("unexpected or missing 'stac_version' member")
@@ -178,7 +178,7 @@ func (v *Validator) validate(resourceUrl string, resource crawler.Resource) erro
 	coreErr := coreSchema.Validate(map[string]interface{}(resource))
 	if coreErr != nil {
 		if err, ok := coreErr.(*jsonschema.ValidationError); ok {
-			return newValidationError(resourceUrl, err)
+			return newValidationError(resourceUrl, resource, err)
 		}
 		return coreErr
 	}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -97,7 +97,7 @@ func ExampleValidator_Validate_children() {
 	err := v.Validate(context.Background(), "testdata/cases/v1.0.0/catalog-with-item-missing-id.json")
 	fmt.Printf("%#v\n", err)
 	// Output:
-	// invalid resource: testdata/cases/v1.0.0/item-missing-id.json
+	// invalid item: testdata/cases/v1.0.0/item-missing-id.json
 	// [I#] [S#] doesn't validate with https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#
 	//   [I#] [S#/allOf/0] allOf failed
 	//     [I#] [S#/allOf/0/$ref] doesn't validate with '/definitions/core'
@@ -114,7 +114,7 @@ func ExampleValidator_Validate_single() {
 	err := v.Validate(context.Background(), "testdata/cases/v1.0.0/item-missing-id.json")
 	fmt.Printf("%#v\n", err)
 	// Output:
-	// invalid resource: testdata/cases/v1.0.0/item-missing-id.json
+	// invalid item: testdata/cases/v1.0.0/item-missing-id.json
 	// [I#] [S#] doesn't validate with https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#
 	//   [I#] [S#/allOf/0] allOf failed
 	//     [I#] [S#/allOf/0/$ref] doesn't validate with '/definitions/core'


### PR DESCRIPTION
This change updates the formatting of the logs for `stac validate`.  Validation errors now include the resource type.  Exit code 1 is for argument errors, 2 for validation, and 3 for other.