### PR TITLE
Retain double slashes when creating absolute URLs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v2
         with:
           version: v1.45.2
+          args: "--out-${NO_FUTURE}format colored-line-number"
 
   test:
     runs-on: ubuntu-latest

--- a/cmd/stac/make-links-absolute_test.go
+++ b/cmd/stac/make-links-absolute_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeAbsoluteUrl(t *testing.T) {
+	cases := []struct {
+		dir  string
+		link string
+		base string
+		abs  string
+	}{
+		{
+			dir:  "some/dir",
+			link: "./item.json",
+			base: "https://example.com/stac",
+			abs:  "https://example.com/stac/some/dir/item.json",
+		},
+		{
+			dir:  "some/dir",
+			link: "item.json",
+			base: "https://example.com/stac",
+			abs:  "https://example.com/stac/some/dir/item.json",
+		},
+		{
+			dir:  "some/dir",
+			link: "../../catalog.json",
+			base: "https://example.com/stac",
+			abs:  "https://example.com/stac/catalog.json",
+		},
+		{
+			dir:  "some/dir",
+			link: "../../../../../../catalog.json",
+			base: "https://example.com/stac",
+			abs:  "https://example.com/catalog.json",
+		},
+		{
+			dir:  "../some/dir",
+			link: "other/catalog.json",
+			base: "https://example.com/stac",
+			abs:  "https://example.com/some/dir/other/catalog.json",
+		},
+		{
+			dir:  "some-dir",
+			link: "https://example.com/some-dir/item.json",
+			base: "https://other.com/stac",
+			abs:  "https://example.com/some-dir/item.json",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			linkUrl, err := url.Parse(c.link)
+			require.NoError(t, err)
+
+			baseUrl, err := url.Parse(c.base)
+			require.NoError(t, err)
+
+			absUrl := makeAbsolute(linkUrl, c.dir, baseUrl)
+			assert.Equal(t, c.abs, absUrl.String())
+		})
+	}
+}


### PR DESCRIPTION
This fixes an issue in the `stac make-links-absolute` command where URLs like `http:/example.com/stac/catalog.json` would be produced (note the single slash after `http:`)