### PR TITLE
Visit top-level API catalog

### DIFF
--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -264,7 +264,7 @@ func (c *Crawler) crawlResource(worker *workgroup.Worker[*task], resourceUrl str
 						return err
 					}
 					worker.Add(&task{url: linkURL, kind: collectionsTask})
-					return nil
+					return c.visitor(resourceUrl, resource)
 				}
 			}
 		}

--- a/crawler/testdata/v1.0.0/api-catalog.json
+++ b/crawler/testdata/v1.0.0/api-catalog.json
@@ -1,0 +1,17 @@
+{
+  "stac_version": "1.0.0",
+  "type": "Catalog",
+  "id": "api-catalog",
+  "description": "A valid API catalog",
+  "conformsTo" : [
+    "https://api.stacspec.org/v1.0.0-rc.1/core",
+    "https://api.stacspec.org/v1.0.0-rc.1/ogcapi-features"
+  ],
+  "links": [
+    {
+      "rel": "data",
+      "type": "application/json",
+      "href": "./api-collections.json"
+    }
+  ]
+}

--- a/crawler/testdata/v1.0.0/api-collections.json
+++ b/crawler/testdata/v1.0.0/api-collections.json
@@ -1,0 +1,47 @@
+{
+  "collections": [
+    {
+      "stac_version": "1.0.0",
+      "type": "Collection",
+      "id": "collection-with-items",
+      "description": "A valid collection",
+      "license": "CC-BY-4.0",
+      "extent": {
+        "spatial": {
+          "bbox": [
+            [
+              0,
+              0,
+              0,
+              0
+            ]
+          ]
+        },
+        "temporal": {
+          "interval": [
+            [
+              "2022-03-22T00:00:00Z",
+              "2022-03-23T00:00:00Z"
+            ]
+          ]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/json",
+          "href": "./collection-with-items.json"
+        },
+        {
+          "rel": "items",
+          "type": "application/geo+json",
+          "href": "./api-items.json"
+        },
+        {
+          "rel": "root",
+          "href": "./api-catalog.json"
+        }
+      ]
+    }
+  ]
+}

--- a/crawler/testdata/v1.0.0/api-items.json
+++ b/crawler/testdata/v1.0.0/api-items.json
@@ -1,0 +1,42 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "stac_version": "1.0.0",
+      "type": "Feature",
+      "id": "item-in-collection",
+      "bbox": [
+        0,
+        0,
+        0,
+        0
+      ],
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          0,
+          0
+        ]
+      },
+      "properties": {
+        "datetime": "2022-03-22T00:00:00Z"
+      },
+      "links": [
+        {
+          "rel": "self",
+          "type": "application/geo+json",
+          "href": "./item-in-collection.json"
+        },
+        {
+          "rel": "collection",
+          "href": "./collection-with-items.json"
+        },
+        {
+          "rel": "root",
+          "href": "./api-catalog.json"
+        }
+      ],
+      "assets": {}
+    }
+  ]
+}


### PR DESCRIPTION
This makes it so the crawler calls the visitor for top-level API catalogs (instead of only their collections and items).