### PR TITLE
Follow "items" links from collections

### DIFF
--- a/cmd/stac/validate.go
+++ b/cmd/stac/validate.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var recursionValues = []string{string(crawler.All), string(crawler.None), string(crawler.Children)}
+var recursionValues = []string{string(crawler.None), string(crawler.Children)}
 
 var validateCommand = &cli.Command{
 	Name:        "validate",

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -350,14 +350,16 @@ func (c *Crawler) crawlCollections(worker *workgroup.Worker[*Task], collectionsU
 		var selfUrl string
 		var itemsUrl string
 		for _, link := range resource.Links() {
-			if selfUrl == "" && link["rel"] == "self" && link["type"] == "application/json" {
+			rel := link["rel"]
+			linkType := link["type"]
+			if selfUrl == "" && rel == "self" && strings.HasSuffix(linkType, "json") {
 				resolvedUrl, err := resolveURL(collectionsUrl, link["href"])
 				if err != nil {
 					return err
 				}
 				selfUrl = resolvedUrl
 			}
-			if itemsUrl == "" && link["rel"] == "items" && (link["type"] == "application/geo+json" || link["type"] == "application/json") {
+			if itemsUrl == "" && rel == "items" && strings.HasSuffix(linkType, "json") {
 				resolvedUrl, err := resolveURL(collectionsUrl, link["href"])
 				if err != nil {
 					return err
@@ -381,7 +383,7 @@ func (c *Crawler) crawlCollections(worker *workgroup.Worker[*Task], collectionsU
 	}
 
 	for _, link := range response.Links {
-		if link["rel"] == "next" && link["type"] == "application/json" {
+		if link["rel"] == "next" && strings.HasSuffix(link["type"], "json") {
 			nextUrl, err := resolveURL(collectionsUrl, link["href"])
 			if err != nil {
 				return err
@@ -409,7 +411,7 @@ func (c *Crawler) crawlFeatures(worker *workgroup.Worker[*Task], featuresUrl str
 
 		var itemUrl string
 		for _, link := range resource.Links() {
-			if link["rel"] == "self" && link["type"] == "application/geo+json" {
+			if link["rel"] == "self" && strings.HasSuffix(link["type"], "json") {
 				resolvedUrl, err := resolveURL(featuresUrl, link["href"])
 				if err != nil {
 					return err
@@ -428,7 +430,7 @@ func (c *Crawler) crawlFeatures(worker *workgroup.Worker[*Task], featuresUrl str
 	}
 
 	for _, link := range response.Links {
-		if link["rel"] == "next" && link["type"] == "application/json" {
+		if link["rel"] == "next" && strings.HasSuffix(link["type"], "json") {
 			nextUrl, err := resolveURL(featuresUrl, link["href"])
 			if err != nil {
 				return err

--- a/crawler/crawler_test.go
+++ b/crawler/crawler_test.go
@@ -140,26 +140,6 @@ func TestCrawlerChildren(t *testing.T) {
 	assert.Equal(t, uint64(2), count)
 }
 
-func TestCrawlerAll(t *testing.T) {
-	count := uint64(0)
-	visited := &sync.Map{}
-
-	visitor := func(location string, resource crawler.Resource) error {
-		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
-		if loaded {
-			return fmt.Errorf("already visited %s", location)
-		}
-		return nil
-	}
-	c := crawler.New(visitor, &crawler.Options{Recursion: crawler.All})
-
-	err := c.Crawl(context.Background(), "testdata/v1.0.0/item-in-collection.json")
-	assert.NoError(t, err)
-
-	assert.Equal(t, uint64(3), count)
-}
-
 func TestCrawlerCatalog(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
@@ -203,6 +183,32 @@ func TestCrawlerAPI(t *testing.T) {
 	assert.True(t, visitedCatalog)
 
 	_, visitedCollection := visited.Load("testdata/v1.0.0/collection-with-items.json")
+	assert.True(t, visitedCollection)
+
+	_, visitedItem := visited.Load("testdata/v1.0.0/item-in-collection.json")
+	assert.True(t, visitedItem)
+}
+
+func TestCrawlerAPICollection(t *testing.T) {
+	count := uint64(0)
+	visited := &sync.Map{}
+
+	visitor := func(location string, resource crawler.Resource) error {
+		atomic.AddUint64(&count, 1)
+		_, loaded := visited.LoadOrStore(location, true)
+		if loaded {
+			return fmt.Errorf("already visited %s", location)
+		}
+		return nil
+	}
+	c := crawler.New(visitor)
+
+	err := c.Crawl(context.Background(), "testdata/v1.0.0/api-collection.json")
+	assert.NoError(t, err)
+
+	assert.Equal(t, uint64(2), count)
+
+	_, visitedCollection := visited.Load("testdata/v1.0.0/api-collection.json")
 	assert.True(t, visitedCollection)
 
 	_, visitedItem := visited.Load("testdata/v1.0.0/item-in-collection.json")

--- a/crawler/testdata/v1.0.0/api-collection.json
+++ b/crawler/testdata/v1.0.0/api-collection.json
@@ -1,0 +1,43 @@
+{
+  "stac_version": "1.0.0",
+  "type": "Collection",
+  "id": "collection-with-items",
+  "description": "A valid collection",
+  "license": "CC-BY-4.0",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          0,
+          0,
+          0,
+          0
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2022-03-22T00:00:00Z",
+          "2022-03-23T00:00:00Z"
+        ]
+      ]
+    }
+  },
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "href": "./collection-with-items.json"
+    },
+    {
+      "rel": "items",
+      "type": "application/geo+json",
+      "href": "./api-items.json"
+    },
+    {
+      "rel": "root",
+      "href": "./api-catalog.json"
+    }
+  ]
+}


### PR DESCRIPTION
Currently, "items" links are followed when visiting a list of collections (e.g. following a "data" link from an OGC API - Features endpoint).  This change makes it so "items" links are followed when visiting a single collection as well.

This also removes the "all" recursion type.  The only direction to crawl is now down.