### PR TITLE
Always pass absolute paths to the visitor

### DIFF
--- a/crawler/crawler_test.go
+++ b/crawler/crawler_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -179,13 +181,16 @@ func TestCrawlerAPI(t *testing.T) {
 
 	assert.Equal(t, uint64(3), count)
 
-	_, visitedCatalog := visited.Load("testdata/v1.0.0/api-catalog.json")
+	wd, wdErr := os.Getwd()
+	require.NoError(t, wdErr)
+
+	_, visitedCatalog := visited.Load(filepath.Join(wd, "testdata/v1.0.0/api-catalog.json"))
 	assert.True(t, visitedCatalog)
 
-	_, visitedCollection := visited.Load("testdata/v1.0.0/collection-with-items.json")
+	_, visitedCollection := visited.Load(filepath.Join(wd, "testdata/v1.0.0/collection-with-items.json"))
 	assert.True(t, visitedCollection)
 
-	_, visitedItem := visited.Load("testdata/v1.0.0/item-in-collection.json")
+	_, visitedItem := visited.Load(filepath.Join(wd, "testdata/v1.0.0/item-in-collection.json"))
 	assert.True(t, visitedItem)
 }
 
@@ -208,9 +213,12 @@ func TestCrawlerAPICollection(t *testing.T) {
 
 	assert.Equal(t, uint64(2), count)
 
-	_, visitedCollection := visited.Load("testdata/v1.0.0/api-collection.json")
+	wd, wdErr := os.Getwd()
+	require.NoError(t, wdErr)
+
+	_, visitedCollection := visited.Load(filepath.Join(wd, "testdata/v1.0.0/api-collection.json"))
 	assert.True(t, visitedCollection)
 
-	_, visitedItem := visited.Load("testdata/v1.0.0/item-in-collection.json")
+	_, visitedItem := visited.Load(filepath.Join(wd, "testdata/v1.0.0/item-in-collection.json"))
 	assert.True(t, visitedItem)
 }

--- a/internal/normurl/normurl.go
+++ b/internal/normurl/normurl.go
@@ -1,0 +1,96 @@
+package normurl
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+type Locator struct {
+	url        *url.URL
+	isFilepath bool
+}
+
+func (l *Locator) String() string {
+	return l.url.String()
+}
+
+func (l *Locator) IsFilepath() bool {
+	return l.isFilepath
+}
+
+func New(s string) (*Locator, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Scheme == "" {
+		if !filepath.IsAbs(s) {
+			return nil, fmt.Errorf("expected absolute path")
+		}
+		loc := &Locator{
+			url:        u,
+			isFilepath: true,
+		}
+		return loc, nil
+	}
+
+	if u.Scheme == "file" {
+		path := u.Path
+		if runtime.GOOS == "windows" {
+			path = filepath.FromSlash(strings.TrimPrefix(path, "/"))
+		}
+		u.Scheme = ""
+		u.Path = path
+		loc := &Locator{
+			url:        u,
+			isFilepath: true,
+		}
+		return loc, nil
+	}
+
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("unsupported scheme %s", u.Scheme)
+	}
+
+	return &Locator{url: u}, nil
+}
+
+func (base *Locator) Resolve(s string) (*Locator, error) {
+	u, err := url.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+
+	if u.Scheme != "" {
+		return New(s)
+	}
+
+	if base.isFilepath {
+		if filepath.IsAbs(s) {
+			loc := &Locator{
+				url:        u,
+				isFilepath: true,
+			}
+			return loc, nil
+		}
+
+		baseDir := filepath.Dir(base.url.Path)
+		path := filepath.Join(baseDir, s)
+		loc := &Locator{
+			url:        &url.URL{Path: path},
+			isFilepath: true,
+		}
+		return loc, nil
+	}
+
+	resolved := base.url.ResolveReference(u)
+	loc := &Locator{
+		url:        resolved,
+		isFilepath: false,
+	}
+	return loc, nil
+}

--- a/internal/normurl/normurl_test.go
+++ b/internal/normurl/normurl_test.go
@@ -1,0 +1,141 @@
+package normurl_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/planetlabs/go-stac/internal/normurl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNew(t *testing.T) {
+	cases := []struct {
+		input      string
+		expected   string
+		isFilepath bool
+		err        error
+	}{
+		{
+			input:      "https://example.com",
+			expected:   "https://example.com",
+			isFilepath: false,
+		},
+		{
+			input:      "http://example.com/foo/bar",
+			expected:   "http://example.com/foo/bar",
+			isFilepath: false,
+		},
+		{
+			input:      "/foo/bar",
+			expected:   "/foo/bar",
+			isFilepath: true,
+		},
+		{
+			input:      "file:///foo/bar",
+			expected:   "/foo/bar",
+			isFilepath: true,
+		},
+		{
+			input: "foo/bar",
+			err:   errors.New("expected absolute path"),
+		},
+		{
+			input: "bogus://foo/bar",
+			err:   errors.New("unsupported scheme bogus"),
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.input, func(t *testing.T) {
+			l, err := normurl.New(c.input)
+			if c.err != nil {
+				assert.Nil(t, l)
+				require.Error(t, err)
+				assert.EqualError(t, err, c.err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, c.expected, l.String())
+				assert.Equal(t, c.isFilepath, l.IsFilepath())
+			}
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	cases := []struct {
+		base     string
+		input    string
+		expected string
+		err      error
+	}{
+		{
+			base:     "https://example.com",
+			input:    "foo/bar",
+			expected: "https://example.com/foo/bar",
+		},
+		{
+			base:     "https://example.com",
+			input:    "/foo/bar",
+			expected: "https://example.com/foo/bar",
+		},
+		{
+			base:     "https://example.com",
+			input:    "../foo/bar",
+			expected: "https://example.com/foo/bar",
+		},
+		{
+			base:     "/foo/bar",
+			input:    "bam",
+			expected: "/foo/bam",
+		},
+		{
+			base:     "/foo/bar",
+			input:    "./bam",
+			expected: "/foo/bam",
+		},
+		{
+			base:     "/foo/bar",
+			input:    "../../bam",
+			expected: "/bam",
+		},
+		{
+			base:     "/foo/bar/",
+			input:    "bam",
+			expected: "/foo/bar/bam",
+		},
+		{
+			base:     "/foo/bar/",
+			input:    "./bam",
+			expected: "/foo/bar/bam",
+		},
+		{
+			base:     "/foo/bar/",
+			input:    "../../bam",
+			expected: "/bam",
+		},
+		{
+			base:     "/foo/bar/",
+			input:    "https://example.com/bam",
+			expected: "https://example.com/bam",
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			l, err := normurl.New(c.base)
+			require.NoError(t, err)
+
+			resolved, err := l.Resolve(c.input)
+			if c.err != nil {
+				assert.Nil(t, resolved)
+				require.Error(t, err)
+				assert.EqualError(t, err, c.err.Error())
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, c.expected, resolved.String())
+			}
+		})
+	}
+}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/planetlabs/go-stac/crawler"
@@ -87,14 +88,14 @@ func TestSuite(t *testing.T) {
 }
 
 func ExampleValidator_Validate_children() {
-	v := validator.New(&validator.Options{
-		Recursion: crawler.Children,
-	})
+	v := validator.New()
 
 	err := v.Validate(context.Background(), "testdata/cases/v1.0.0/catalog-with-item-missing-id.json")
-	fmt.Printf("%#v\n", err)
+
+	workdir, _ := os.Getwd()
+	fmt.Println(strings.Replace(fmt.Sprintf("%#v\n", err), workdir, "/path/to", 1))
 	// Output:
-	// invalid item: testdata/cases/v1.0.0/item-missing-id.json
+	// invalid item: /path/to/testdata/cases/v1.0.0/item-missing-id.json
 	// [I#] [S#] doesn't validate with https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#
 	//   [I#] [S#/allOf/0] allOf failed
 	//     [I#] [S#/allOf/0/$ref] doesn't validate with '/definitions/core'
@@ -103,14 +104,14 @@ func ExampleValidator_Validate_children() {
 }
 
 func ExampleValidator_Validate_single() {
-	v := validator.New(&validator.Options{
-		Recursion: crawler.None,
-	})
+	v := validator.New()
 
 	err := v.Validate(context.Background(), "testdata/cases/v1.0.0/item-missing-id.json")
-	fmt.Printf("%#v\n", err)
+
+	workdir, _ := os.Getwd()
+	fmt.Println(strings.Replace(fmt.Sprintf("%#v\n", err), workdir, "/path/to", 1))
 	// Output:
-	// invalid item: testdata/cases/v1.0.0/item-missing-id.json
+	// invalid item: /path/to/testdata/cases/v1.0.0/item-missing-id.json
 	// [I#] [S#] doesn't validate with https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#
 	//   [I#] [S#/allOf/0] allOf failed
 	//     [I#] [S#/allOf/0/$ref] doesn't validate with '/definitions/core'


### PR DESCRIPTION
This change reworks the URL/path handling a bit in support of an upcoming change.  During a crawl, the visitor will always get called with absolute paths or URLs (as opposed to sometimes getting relative file paths).