### PR TITLE
More flexible link handling

### DIFF
--- a/crawler/links.go
+++ b/crawler/links.go
@@ -1,0 +1,73 @@
+package crawler
+
+import "strings"
+
+// Link represents a link to a resource.
+type Link map[string]string
+
+// Links is a slice of links.
+type Links []Link
+
+type LinkMatcher func(link Link) bool
+
+type linkCandidate struct {
+	link     Link
+	priority int
+	order    int
+}
+
+func LinkTypeApplicationJSON(link Link) bool {
+	return strings.ToLower(link["type"]) == "application/json"
+}
+
+func LinkTypeAnyJSON(link Link) bool {
+	return strings.HasSuffix(strings.ToLower(link["type"]), "json")
+}
+
+func LinkTypeGeoJSON(link Link) bool {
+	return strings.ToLower(link["type"]) == "application/geo+json"
+}
+
+func LinkTypeNone(link Link) bool {
+	_, hasType := link["type"]
+	return !hasType
+}
+
+func (links Links) Rel(rel string, matchers ...LinkMatcher) Link {
+	candidates := []*linkCandidate{}
+
+	for order, link := range links {
+		if link["rel"] == rel {
+			if len(matchers) == 0 {
+				return link
+			}
+			for priority, matcher := range matchers {
+				if matcher(link) {
+					candidates = append(candidates, &linkCandidate{link: link, priority: priority, order: order})
+				}
+			}
+		}
+	}
+
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	best := candidates[0]
+	for _, candidate := range candidates {
+		if candidate.priority > best.priority {
+			continue
+		}
+
+		if candidate.priority < best.priority {
+			best = candidate
+			continue
+		}
+
+		if candidate.order < best.order {
+			best = candidate
+		}
+	}
+
+	return best.link
+}

--- a/crawler/links_test.go
+++ b/crawler/links_test.go
@@ -1,0 +1,98 @@
+package crawler_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/planetlabs/go-stac/crawler"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLinksRel(t *testing.T) {
+	cases := []struct {
+		links         crawler.Links
+		rel           string
+		matchers      []crawler.LinkMatcher
+		expectedIndex int
+	}{
+		{
+			links: crawler.Links{
+				{"rel": "self", "type": "application/json"},
+			},
+			rel:           "self",
+			matchers:      []crawler.LinkMatcher{crawler.LinkTypeApplicationJSON},
+			expectedIndex: 0,
+		},
+		{
+			links: crawler.Links{
+				{"rel": "other", "type": "text/html"},
+				{"rel": "self", "type": "application/json"},
+			},
+			rel:           "self",
+			matchers:      []crawler.LinkMatcher{crawler.LinkTypeApplicationJSON},
+			expectedIndex: 1,
+		},
+		{
+			links: crawler.Links{
+				{"rel": "self", "type": "text/html"},
+				{"rel": "self", "type": "application/json"},
+			},
+			rel:           "self",
+			matchers:      []crawler.LinkMatcher{crawler.LinkTypeApplicationJSON},
+			expectedIndex: 1,
+		},
+		{
+			links: crawler.Links{
+				{"rel": "self", "type": "text/html"},
+				{"rel": "item", "type": "application/ld+json"},
+				{"rel": "item", "type": "application/json"},
+				{"rel": "item", "type": "application/geo+json"},
+			},
+			rel:           "item",
+			matchers:      []crawler.LinkMatcher{crawler.LinkTypeGeoJSON, crawler.LinkTypeApplicationJSON, crawler.LinkTypeAnyJSON},
+			expectedIndex: 3,
+		},
+		{
+			links: crawler.Links{
+				{"rel": "self", "type": "text/html"},
+				{"rel": "item", "type": "application/ld+json"},
+				{"rel": "item", "type": "application/json"},
+				{"rel": "item"},
+			},
+			rel:           "item",
+			matchers:      []crawler.LinkMatcher{crawler.LinkTypeGeoJSON, crawler.LinkTypeApplicationJSON, crawler.LinkTypeAnyJSON},
+			expectedIndex: 2,
+		},
+		{
+			links: crawler.Links{
+				{"rel": "self", "type": "text/html"},
+				{"rel": "item", "type": "text/html"},
+				{"rel": "item"},
+			},
+			rel:           "item",
+			matchers:      []crawler.LinkMatcher{crawler.LinkTypeGeoJSON, crawler.LinkTypeApplicationJSON, crawler.LinkTypeAnyJSON, crawler.LinkTypeNone},
+			expectedIndex: 2,
+		},
+		{
+			links: crawler.Links{
+				{"rel": "self", "type": "text/html"},
+				{"rel": "item", "type": "application/geo+json"},
+				{"rel": "item"},
+			},
+			rel:           "item",
+			matchers:      []crawler.LinkMatcher{crawler.LinkTypeApplicationJSON, crawler.LinkTypeAnyJSON, crawler.LinkTypeNone},
+			expectedIndex: 1,
+		},
+	}
+
+	for i, c := range cases {
+		t.Run(fmt.Sprintf("case %d", i), func(t *testing.T) {
+			link := c.links.Rel(c.rel, c.matchers...)
+			if c.expectedIndex == -1 {
+				assert.Nil(t, link)
+			} else {
+				assert.Equal(t, c.links[c.expectedIndex], link)
+			}
+		})
+	}
+}

--- a/crawler/resources.go
+++ b/crawler/resources.go
@@ -82,11 +82,8 @@ func (r Resource) Version() string {
 	return version
 }
 
-// Link represents a link to a resource.
-type Link map[string]string
-
 // Links returns the resource links.
-func (r Resource) Links() []Link {
+func (r Resource) Links() Links {
 	links := []Link{}
 	value, ok := r["links"]
 	if !ok {
@@ -137,10 +134,10 @@ func (r Resource) Extensions() []string {
 
 type featureCollectionsResponse struct {
 	Collections []Resource `json:"collections"`
-	Links       []Link     `json:"links"`
+	Links       Links      `json:"links"`
 }
 
 type featureCollectionResponse struct {
 	Features []Resource `json:"features"`
-	Links    []Link     `json:"links"`
+	Links    Links      `json:"links"`
 }


### PR DESCRIPTION
This adds a convenience function for getting a link with a list of prioritized matchers.  This makes it possible to handle the variety of links found in practice (using `application/json` for GeoJSON, omitting the `type` altogether, etc.).