### PR TITLE
Guess resource types for more legacy versions

### DIFF
--- a/crawler/resources.go
+++ b/crawler/resources.go
@@ -1,5 +1,11 @@
 package crawler
 
+import (
+	"fmt"
+
+	"golang.org/x/mod/semver"
+)
+
 const (
 	versionKey    = "stac_version"
 	extensionsKey = "stac_extensions"
@@ -17,12 +23,16 @@ const (
 // Resource represents a STAC catalog, collection, or item.
 type Resource map[string]interface{}
 
+func (r Resource) compareVersion(otherVersion string) int {
+	return semver.Compare(fmt.Sprintf("v%s", r.Version()), fmt.Sprintf("v%s", otherVersion))
+}
+
 // Type returns the specific resource type.
 func (r Resource) Type() ResourceType {
 	value, ok := r["type"]
 	if !ok {
-		// try to guess the resource type for 1.0.0-beta.2
-		if r.Version() == "1.0.0-beta.2" {
+		// try to guess the resource type for <= 1.0.0-beta.2
+		if r.compareVersion("1.0.0-beta.2") <= 0 {
 			if _, ok := r["extent"]; ok {
 				return Collection
 			}

--- a/crawler/testdata/v0.8.1/5633320870809797824_root_collection.json
+++ b/crawler/testdata/v0.8.1/5633320870809797824_root_collection.json
@@ -1,0 +1,71 @@
+{
+  "id": "5633320870809797824",
+  "stac_version": "0.8.1",
+  "description": "Order 5633320870809797824 collection",
+  "links": [
+    {
+      "rel": "root",
+      "href": "./5633320870809797824_root_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": "../acquisition_collections/10300100B51C4600_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": "../acquisition_collections/10300100B0A32C00_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": "../acquisition_collections/103001009BD57700_collection.json",
+      "type": "application/json"
+    },
+    {
+      "rel": "child",
+      "href": "../acquisition_collections/103001008815D500_collection.json",
+      "type": "application/json"
+    }
+  ],
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          43.104744579911056,
+          36.2635417013712,
+          43.21949284212573,
+          36.358231483123724
+        ],
+        [
+          43.104744579911056,
+          36.280714293351785,
+          43.21949284212573,
+          36.358231483123724
+        ],
+        [
+          43.104744579911056,
+          36.2635417013712,
+          43.21949284212573,
+          36.358231483123724
+        ],
+        [
+          43.104744579911056,
+          36.2635417013712,
+          43.21949284212573,
+          36.358231483123724
+        ]
+      ]
+    },
+    "temporal": {
+      "interval": [
+        [
+          "2018-12-15 07:58:38Z",
+          "2021-02-26 07:49:44Z"
+        ]
+      ]
+    }
+  },
+  "license": "proprietary"
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/tschaub/workgroup v0.4.0
 	github.com/urfave/cli/v2 v2.4.0
 	go.uber.org/zap v1.21.0
+	golang.org/x/mod v0.4.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 )
 

--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838 h1:71vQrMauZZhcTVK6KdYM+rklehEEwb3E+ZhaE5jrPrE=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/lint v0.0.0-20190930215403-16217165b5de/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/mod v0.4.2 h1:Gz96sIWK3OalVv/I/qNygP42zyoKp3xptRVCWRFEBvo=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
This makes it so we try to guess the resource type for versions before 1.0.0-beta.2.