### PR TITLE
Try to guess the type if missing

### DIFF
--- a/crawler/resources.go
+++ b/crawler/resources.go
@@ -31,14 +31,11 @@ func (r Resource) compareVersion(otherVersion string) int {
 func (r Resource) Type() ResourceType {
 	value, ok := r["type"]
 	if !ok {
-		// try to guess the resource type for <= 1.0.0-beta.2
-		if r.compareVersion("1.0.0-beta.2") <= 0 {
-			if _, ok := r["extent"]; ok {
-				return Collection
-			}
-			if _, ok := r["id"]; ok {
-				return Catalog
-			}
+		if _, ok := r["extent"]; ok {
+			return Collection
+		}
+		if _, ok := r["id"]; ok {
+			return Catalog
 		}
 		return ""
 	}


### PR DESCRIPTION
Even after 1.0, there are catalogs out there that are missing the `type` member (e.g. https://meeo-s5p.s3.amazonaws.com/catalog.json).  This change makes it so the resource type is guessed if not present.