### PR TITLE
Function to join or resume an existing crawl

### DIFF
--- a/cmd/stac/format.go
+++ b/cmd/stac/format.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -182,11 +181,9 @@ var formatCommand = &cli.Command{
 			return nil
 		}
 
-		c := crawler.New(visitor, &crawler.Options{
+		return crawler.Crawl(entryPath, visitor, &crawler.Options{
 			Concurrency: ctx.Int(flagConcurrency),
 			Recursion:   crawler.RecursionType(ctx.String(flagRecursion)),
 		})
-
-		return c.Crawl(context.Background(), entryPath)
 	},
 }

--- a/cmd/stac/make-links-absolute.go
+++ b/cmd/stac/make-links-absolute.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -106,12 +105,10 @@ var absoluteLinksCommand = &cli.Command{
 			return nil
 		}
 
-		c := crawler.New(visitor, &crawler.Options{
+		return crawler.Crawl(entryPath, visitor, &crawler.Options{
 			Concurrency: ctx.Int(flagConcurrency),
 			Recursion:   crawler.RecursionType(ctx.String(flagRecursion)),
 		})
-
-		return c.Crawl(context.Background(), entryPath)
 	},
 }
 

--- a/cmd/stac/stats.go
+++ b/cmd/stac/stats.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -92,12 +91,10 @@ var statsCommand = &cli.Command{
 			return nil
 		}
 
-		c := crawler.New(visitor, &crawler.Options{
+		err := crawler.Crawl(entryPath, visitor, &crawler.Options{
 			Concurrency: ctx.Int(flagConcurrency),
 			Recursion:   crawler.RecursionType(ctx.String(flagRecursion)),
 		})
-
-		err := c.Crawl(context.Background(), entryPath)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -11,11 +11,11 @@ require (
 	github.com/schollz/progressbar/v3 v3.8.6
 	github.com/stretchr/testify v1.7.1
 	github.com/tschaub/retry v1.0.0
-	github.com/tschaub/workgroup v0.4.0
+	github.com/tschaub/workgroup v0.4.1
 	github.com/urfave/cli/v2 v2.4.0
 	go.uber.org/zap v1.21.0
 	golang.org/x/mod v0.4.2
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/tschaub/limited v0.2.0 h1:XBjhp4JNhRruzRlU4/RCLGxxSmRPO+rJelpB5EVZYJU
 github.com/tschaub/limited v0.2.0/go.mod h1:MpOH3bHLpfI+6MO7P1DulWY4aXXqKdkUn8v4eMm4xOI=
 github.com/tschaub/retry v1.0.0 h1:zY9jeVNPxv2UovkFikgYOpvT5q52/3KQuJrY70MK+ws=
 github.com/tschaub/retry v1.0.0/go.mod h1:yBQOt5++ZYLg8LqzLICIFMmiG7WM45CYCnemriP95T8=
-github.com/tschaub/workgroup v0.4.0 h1:xiFUdRp/tYl6sFXcT5b7jLoUEcIh/mgue1BQRrEhITY=
-github.com/tschaub/workgroup v0.4.0/go.mod h1:UEtjKJmK1+hsGa6zC1sSHC6iZh8GmzesqybVruhdGX8=
+github.com/tschaub/workgroup v0.4.1 h1:ceOJsWBgPT6BPgnpErF9L0AUyiSMitMAdJacWHUqqGY=
+github.com/tschaub/workgroup v0.4.1/go.mod h1:2+S8HaK4tzsfn7NkaLtJpnuO04NjSk/w5pRuafqwYoo=
 github.com/urfave/cli/v2 v2.4.0 h1:m2pxjjDFgDxSPtO8WSdbndj17Wu2y8vOT86wE/tjr+I=
 github.com/urfave/cli/v2 v2.4.0/go.mod h1:NX9W0zmTvedE5oDoOMs2RTC8RvdK98NTYZE5LbaEYPg=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
@@ -83,8 +83,9 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -157,11 +157,11 @@ func schemaUrl(version string, resourceType crawler.ResourceType) string {
 // returned.  Context cancellation will also stop validation and the context
 // error will be returned.
 func (v *Validator) Validate(ctx context.Context, resource string) error {
-	c := crawler.New(v.validate, &crawler.Options{
+	return crawler.Crawl(resource, v.validate, &crawler.Options{
+		Context:     ctx,
 		Concurrency: v.concurrency,
 		Recursion:   v.recursion,
 	})
-	return c.Crawl(ctx, resource)
 }
 
 func (v *Validator) validate(resourceUrl string, resource crawler.Resource) error {


### PR DESCRIPTION
When using a shared queue for a crawl (e.g. a Redis-backed queue), it can be useful to be able to resume an existing crawl when one crawler gets taken down.  The new `Join` function can be used to resume or add crawlers to an existing crawl.  

This change also minimizes the API in the `crawler` package, exposing just `Crawl` (to initiate a new crawl) and `Join` (to join/resume an existing crawl).