### PR TITLE
Accept an error handler

### DIFF
--- a/crawler/testdata/v1.0.0/catalog-with-one-invalid-collection.json
+++ b/crawler/testdata/v1.0.0/catalog-with-one-invalid-collection.json
@@ -1,0 +1,20 @@
+{
+  "stac_version": "1.0.0",
+  "type": "Catalog",
+  "id": "catalog-with-one-invalid-collection",
+  "description": "A catalog with an invalid collection",
+  "links": [
+    {
+      "rel": "self",
+      "href": "./catalog-with-one-invalid-collection.json"
+    },
+    {
+      "rel": "child",
+      "href": "./invalid-json.txt"
+    },
+    {
+      "rel": "child",
+      "href": "./collection-with-items.json"
+    }
+  ]
+}

--- a/crawler/testdata/v1.0.0/invalid-json.txt
+++ b/crawler/testdata/v1.0.0/invalid-json.txt
@@ -1,0 +1,3 @@
+{
+  this is not json
+}


### PR DESCRIPTION
The new `ErrorHandler` option allows a crawler to be configured with an error handler.  The error handler will be called with errors during the crawl.  These include errors loading or parsing data, errors from any visitor, and errors extracting links.  If the error handler returns null, the crawl will continue.  Otherwise, the crawl will stop.