### PR TITLE
Support the STAC API - Children conformance class

### DIFF
--- a/crawler/resources.go
+++ b/crawler/resources.go
@@ -159,3 +159,8 @@ type featureCollectionResponse struct {
 	Features []Resource `json:"features"`
 	Links    Links      `json:"links"`
 }
+
+type childrenResponse struct {
+	Children []Resource `json:"children"`
+	Links    Links      `json:"links"`
+}

--- a/crawler/testdata/v1.0.0/api-catalog-with-children.json
+++ b/crawler/testdata/v1.0.0/api-catalog-with-children.json
@@ -1,0 +1,38 @@
+{
+  "stac_version": "1.0.0",
+  "id": "example-stac",
+  "title": "A simple STAC API Example, implementing STAC API - Children",
+  "description": "This Catalog aims to demonstrate the a simple landing page",
+  "type": "Catalog",
+  "conformsTo": [
+    "https://api.stacspec.org/v1.0.0-rc.1/core",
+    "https://api.stacspec.org/v1.0.0-rc.1/children"
+  ],
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/json",
+      "href": "./api-catalog-with-children.com"
+    },
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "./api-catalog-with-children.com"
+    },
+    {
+      "rel": "service-desc",
+      "type": "application/vnd.oai.openapi+json;version=3.0",
+      "href": "https://stac-api.example.com/api"
+    },
+    {
+      "rel": "service-doc",
+      "type": "text/html",
+      "href": "https://stac-api.example.com/api.html"
+    },
+    {
+      "rel": "children",
+      "type": "application/json",
+      "href": "./api-children.json"
+    }
+  ]
+}

--- a/crawler/testdata/v1.0.0/api-children.json
+++ b/crawler/testdata/v1.0.0/api-children.json
@@ -1,0 +1,62 @@
+{
+  "children": [
+    {
+      "stac_version": "1.0.0",
+      "stac_extensions": [],
+      "id": "one-catalog",
+      "type": "Catalog",
+      "links": [
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "./api-catalog-with-children.json"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "./api-catalog-with-children.json"
+        },
+        {
+          "rel": "self",
+          "type": "application/json",
+          "href": "./catalog-with-collection-of-items.json"
+        }
+      ]
+    },
+    {
+      "stac_version": "1.0.0",
+      "stac_extensions": [],
+      "id": "another-catalog",
+      "type": "Catalog",
+      "links": [
+        {
+          "rel": "root",
+          "type": "application/json",
+          "href": "./api-catalog-with-children.json"
+        },
+        {
+          "rel": "parent",
+          "type": "application/json",
+          "href": "./api-catalog-with-children.json"
+        },
+        {
+          "rel": "self",
+          "type": "application/json",
+          "href": "./catalog.json"
+        }
+      ]
+    }
+  ],
+  "links": [
+    {
+      "rel": "root",
+      "type": "application/json",
+      "href": "https://stac-api.example.com"
+    },
+    {
+      "rel": "self",
+      "type": "application/json",
+      "href": "https://stac-api.example.com/children"
+    }
+  ]
+}

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -83,38 +83,22 @@ func (s *Suite) TestSchemaMap() {
 	s.Assert().NoError(err)
 }
 
-func TestSuite(t *testing.T) {
-	suite.Run(t, &Suite{})
-}
-
-func ExampleValidator_Validate_children() {
+func (s *Suite) TestCatalogWithInvalidItem() {
 	v := validator.New()
 
 	err := v.Validate(context.Background(), "testdata/cases/v1.0.0/catalog-with-item-missing-id.json")
-
-	workdir, _ := os.Getwd()
-	fmt.Println(strings.Replace(fmt.Sprintf("%#v\n", err), workdir, "/path/to", 1))
-	// Output:
-	// invalid item: /path/to/testdata/cases/v1.0.0/item-missing-id.json
-	// [I#] [S#] doesn't validate with https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#
-	//   [I#] [S#/allOf/0] allOf failed
-	//     [I#] [S#/allOf/0/$ref] doesn't validate with '/definitions/core'
-	//       [I#] [S#/definitions/core/allOf/2] allOf failed
-	//         [I#] [S#/definitions/core/allOf/2/required] missing properties: 'id'
+	s.Require().Error(err)
+	s.Assert().True(strings.HasSuffix(fmt.Sprintf("%#v", err), "missing properties: 'id'"))
 }
 
-func ExampleValidator_Validate_single() {
+func (s *Suite) TestInvalidItem() {
 	v := validator.New()
 
 	err := v.Validate(context.Background(), "testdata/cases/v1.0.0/item-missing-id.json")
+	s.Require().Error(err)
+	s.Assert().True(strings.HasSuffix(fmt.Sprintf("%#v", err), "missing properties: 'id'"))
+}
 
-	workdir, _ := os.Getwd()
-	fmt.Println(strings.Replace(fmt.Sprintf("%#v\n", err), workdir, "/path/to", 1))
-	// Output:
-	// invalid item: /path/to/testdata/cases/v1.0.0/item-missing-id.json
-	// [I#] [S#] doesn't validate with https://schemas.stacspec.org/v1.0.0/item-spec/json-schema/item.json#
-	//   [I#] [S#/allOf/0] allOf failed
-	//     [I#] [S#/allOf/0/$ref] doesn't validate with '/definitions/core'
-	//       [I#] [S#/definitions/core/allOf/2] allOf failed
-	//         [I#] [S#/definitions/core/allOf/2/required] missing properties: 'id'
+func TestSuite(t *testing.T) {
+	suite.Run(t, &Suite{})
 }


### PR DESCRIPTION
This adds support for crawling "children" links in STAC API catalogs.