### PR TITLE
Allow recursion to be stopped at any point

### DIFF
--- a/cmd/stac/format.go
+++ b/cmd/stac/format.go
@@ -8,7 +8,6 @@ import (
 	"path"
 	"path/filepath"
 	"sort"
-	"strings"
 
 	"github.com/planetlabs/go-stac/crawler"
 	"github.com/urfave/cli/v2"
@@ -136,14 +135,10 @@ var formatCommand = &cli.Command{
 			Value:   crawler.DefaultOptions.Concurrency,
 			EnvVars: []string{toEnvVar(flagConcurrency)},
 		},
-		&cli.GenericFlag{
-			Name:  flagRecursion,
-			Usage: fmt.Sprintf("Recursion type (%s)", strings.Join(recursionValues, ", ")),
-			Value: &Enum{
-				Values:  recursionValues,
-				Default: string(crawler.DefaultOptions.Recursion),
-			},
-			EnvVars: []string{toEnvVar(flagRecursion)},
+		&cli.BoolFlag{
+			Name:    flagNoRecursion,
+			Usage:   "Visit a single resource",
+			EnvVars: []string{toEnvVar(flagNoRecursion)},
 		},
 	},
 	Action: func(ctx *cli.Context) error {
@@ -157,6 +152,8 @@ var formatCommand = &cli.Command{
 		if outputPath == "" {
 			return fmt.Errorf("missing --%s", flagOutput)
 		}
+
+		noRecursion := ctx.Bool(flagNoRecursion)
 
 		visitor := func(location string, resource crawler.Resource) error {
 			relDir, err := filepath.Rel(baseDir, path.Dir(location))
@@ -178,12 +175,16 @@ var formatCommand = &cli.Command{
 			if err := os.WriteFile(outFile, data, 0644); err != nil {
 				return fmt.Errorf("failed to write %s: %w", outFile, err)
 			}
+
+			if noRecursion {
+				return crawler.ErrStopRecursion
+			}
+
 			return nil
 		}
 
 		return crawler.Crawl(entryPath, visitor, &crawler.Options{
 			Concurrency: ctx.Int(flagConcurrency),
-			Recursion:   crawler.RecursionType(ctx.String(flagRecursion)),
 		})
 	},
 }

--- a/cmd/stac/main.go
+++ b/cmd/stac/main.go
@@ -31,7 +31,7 @@ const (
 	flagEntry       = "entry"
 	flagOutput      = "output"
 	flagConcurrency = "concurrency"
-	flagRecursion   = "recursion"
+	flagNoRecursion = "no-recursion"
 )
 
 type Enum struct {

--- a/cmd/stac/validate.go
+++ b/cmd/stac/validate.go
@@ -11,8 +11,6 @@ import (
 	"go.uber.org/zap"
 )
 
-var recursionValues = []string{string(crawler.None), string(crawler.Children)}
-
 var validateCommand = &cli.Command{
 	Name:        "validate",
 	Usage:       "Validate STAC metadata",
@@ -34,14 +32,10 @@ var validateCommand = &cli.Command{
 			Value:   crawler.DefaultOptions.Concurrency,
 			EnvVars: []string{toEnvVar(flagConcurrency)},
 		},
-		&cli.GenericFlag{
-			Name:  flagRecursion,
-			Usage: fmt.Sprintf("Recursion type (%s)", strings.Join(recursionValues, ", ")),
-			Value: &Enum{
-				Values:  recursionValues,
-				Default: string(crawler.DefaultOptions.Recursion),
-			},
-			EnvVars: []string{toEnvVar(flagRecursion)},
+		&cli.BoolFlag{
+			Name:    flagNoRecursion,
+			Usage:   "Visit a single resource",
+			EnvVars: []string{toEnvVar(flagNoRecursion)},
 		},
 		&cli.GenericFlag{
 			Name:  flagLogLevel,
@@ -76,7 +70,7 @@ var validateCommand = &cli.Command{
 
 		v := validator.New(&validator.Options{
 			Concurrency: ctx.Int(flagConcurrency),
-			Recursion:   crawler.RecursionType(ctx.String(flagRecursion)),
+			NoRecursion: ctx.Bool(flagNoRecursion),
 			SchemaMap:   schemaMap,
 			Logger:      logger,
 		})

--- a/crawler/crawler_test.go
+++ b/crawler/crawler_test.go
@@ -184,11 +184,11 @@ func TestCrawlerSingle(t *testing.T) {
 		if loaded {
 			return fmt.Errorf("already visited %s", location)
 		}
-		return nil
+		return crawler.ErrStopRecursion
 	}
 	entry := "testdata/v1.0.0/catalog-with-collection-of-items.json"
 
-	err := crawler.Crawl(entry, visitor, &crawler.Options{Recursion: crawler.None})
+	err := crawler.Crawl(entry, visitor)
 	assert.NoError(t, err)
 
 	assert.Equal(t, uint64(1), count)
@@ -204,11 +204,11 @@ func TestCrawlerCollection081(t *testing.T) {
 		if loaded {
 			return fmt.Errorf("already visited %s", location)
 		}
-		return nil
+		return crawler.ErrStopRecursion
 	}
 	entry := "testdata/v0.8.1/5633320870809797824_root_collection.json"
 
-	err := crawler.Crawl(entry, visitor, &crawler.Options{Recursion: crawler.None})
+	err := crawler.Crawl(entry, visitor)
 	assert.NoError(t, err)
 
 	assert.Equal(t, uint64(1), count)
@@ -237,7 +237,7 @@ func TestCrawlerChildren(t *testing.T) {
 		}
 		return nil
 	}
-	err := crawler.Crawl("testdata/v1.0.0/collection-with-items.json", visitor, &crawler.Options{Recursion: crawler.Children})
+	err := crawler.Crawl("testdata/v1.0.0/collection-with-items.json", visitor)
 	assert.NoError(t, err)
 
 	assert.Equal(t, uint64(2), count)

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -72,7 +72,6 @@ func (s *Suite) TestValidCases() {
 func (s *Suite) TestSchemaMap() {
 	v := validator.New(&validator.Options{
 		Concurrency: crawler.DefaultOptions.Concurrency,
-		Recursion:   crawler.DefaultOptions.Recursion,
 		SchemaMap: map[string]string{
 			"https://stac-extensions.github.io/custom/v1.0.0/schema.json": "https://example.com//extensions/custom.json",
 		},


### PR DESCRIPTION
The current options for recursion are to visit a single resource, or recursively visit all resources.  This branch removes the recursion option in favor of a special `ErrStopRecursion` error.  Recursion can be stopped at any level if a visitor returns this error (or one that wraps it).