### PR TITLE
Add tasks in batches

### DIFF
--- a/crawler/queue.go
+++ b/crawler/queue.go
@@ -82,7 +82,7 @@ func (t *Task) MarshalJSON() ([]byte, error) {
 type Handler func(task *Task) error
 
 type Queue interface {
-	Add(task *Task) error
+	Add(tasks []*Task) error
 	Handle(handler Handler)
 	Wait() error
 }
@@ -111,9 +111,9 @@ type memoryQueue struct {
 	handler Handler
 }
 
-func (q *memoryQueue) Add(task *Task) error {
+func (q *memoryQueue) Add(tasks []*Task) error {
 	q.mutex.Lock()
-	q.buffer = append(q.buffer, task)
+	q.buffer = append(q.buffer, tasks...)
 	q.mutex.Unlock()
 	q.process()
 	return nil


### PR DESCRIPTION
This changes the custom crawler queue interface to accept slices of tasks in the add method.  This allows the handler provided by the crawler to be atomic in terms of visiting and adding new tasks during recursion.  Only if the visitor succeeds and all child tasks are successfully added does the handler succeed.