### PR TITLE
Provide additional info to the visitor

### DIFF
--- a/cmd/stac/format.go
+++ b/cmd/stac/format.go
@@ -149,8 +149,8 @@ var formatCommand = &cli.Command{
 
 		noRecursion := ctx.Bool(flagNoRecursion)
 
-		visitor := func(location string, resource crawler.Resource) error {
-			relDir, err := filepath.Rel(baseDir, path.Dir(location))
+		visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
+			relDir, err := filepath.Rel(baseDir, path.Dir(info.Location))
 			if err != nil {
 				return fmt.Errorf("failed to make relative path: %w", err)
 			}
@@ -163,9 +163,9 @@ var formatCommand = &cli.Command{
 
 			data, err := json.MarshalIndent(orderedMap(resource), "", "  ")
 			if err != nil {
-				return fmt.Errorf("failed to encode %s: %w", location, err)
+				return fmt.Errorf("failed to encode %s: %w", info.Location, err)
 			}
-			outFile := filepath.Join(outDir, path.Base(location))
+			outFile := filepath.Join(outDir, path.Base(info.Location))
 			if err := os.WriteFile(outFile, data, 0644); err != nil {
 				return fmt.Errorf("failed to write %s: %w", outFile, err)
 			}

--- a/cmd/stac/make-links-absolute.go
+++ b/cmd/stac/make-links-absolute.go
@@ -62,8 +62,8 @@ var absoluteLinksCommand = &cli.Command{
 
 		noRecursion := ctx.Bool(flagNoRecursion)
 
-		visitor := func(location string, resource crawler.Resource) error {
-			relDir, err := filepath.Rel(baseDir, path.Dir(location))
+		visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
+			relDir, err := filepath.Rel(baseDir, path.Dir(info.Location))
 			if err != nil {
 				return fmt.Errorf("failed to make relative path: %w", err)
 			}
@@ -87,9 +87,9 @@ var absoluteLinksCommand = &cli.Command{
 
 			data, err := json.MarshalIndent(resource, "", "  ")
 			if err != nil {
-				return fmt.Errorf("failed to encode %s: %w", location, err)
+				return fmt.Errorf("failed to encode %s: %w", info.Location, err)
 			}
-			outFile := filepath.Join(outDir, path.Base(location))
+			outFile := filepath.Join(outDir, path.Base(info.Location))
 			if err := os.WriteFile(outFile, data, 0644); err != nil {
 				return fmt.Errorf("failed to write %s: %w", outFile, err)
 			}

--- a/cmd/stac/stats.go
+++ b/cmd/stac/stats.go
@@ -73,7 +73,7 @@ var statsCommand = &cli.Command{
 		skip := ctx.Bool(flagExcludeEntry)
 		noRecursion := ctx.Bool(flagNoRecursion)
 
-		visitor := func(location string, resource crawler.Resource) error {
+		visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 			if skip {
 				skip = false
 				return nil

--- a/crawler/assets_test.go
+++ b/crawler/assets_test.go
@@ -12,7 +12,7 @@ import (
 func TestAssets(t *testing.T) {
 	count := uint64(0)
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
 
 		assert.Equal(t, crawler.Item, resource.Type())

--- a/crawler/crawler_test.go
+++ b/crawler/crawler_test.go
@@ -20,11 +20,11 @@ func TestCrawler(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -51,11 +51,11 @@ func TestCrawlerFilterItem(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -84,11 +84,11 @@ func TestCrawlerFilterCollection(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -117,11 +117,11 @@ func TestCrawlerHTTP(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -157,11 +157,11 @@ func TestCrawlerHTTPRetry(t *testing.T) {
 
 	count := uint64(0)
 	visited := &sync.Map{}
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -178,11 +178,11 @@ func TestCrawlerSingle(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return crawler.ErrStopRecursion
 	}
@@ -198,11 +198,11 @@ func TestCrawlerCollection081(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, resource)
+		_, loaded := visited.LoadOrStore(info.Location, resource)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return crawler.ErrStopRecursion
 	}
@@ -229,11 +229,11 @@ func TestCrawlerChildren(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -247,11 +247,11 @@ func TestCrawlerCatalog(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -265,11 +265,11 @@ func TestCrawlerInvalidJSON(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -285,11 +285,11 @@ func TestCrawlerCatalogWithBadCollection(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -313,11 +313,11 @@ func TestCrawlerErrorHandler(t *testing.T) {
 		return nil
 	}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -348,11 +348,11 @@ func TestCrawlerAPI(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -380,11 +380,11 @@ func TestCrawlerAPICollection(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}
@@ -409,11 +409,11 @@ func TestCrawlerAPIChildren(t *testing.T) {
 	count := uint64(0)
 	visited := &sync.Map{}
 
-	visitor := func(location string, resource crawler.Resource) error {
+	visitor := func(resource crawler.Resource, info *crawler.ResourceInfo) error {
 		atomic.AddUint64(&count, 1)
-		_, loaded := visited.LoadOrStore(location, true)
+		_, loaded := visited.LoadOrStore(info.Location, true)
 		if loaded {
-			return fmt.Errorf("already visited %s", location)
+			return fmt.Errorf("already visited %s", info.Location)
 		}
 		return nil
 	}

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -160,8 +160,8 @@ func (v *Validator) Validate(ctx context.Context, resource string) error {
 	})
 }
 
-func (v *Validator) validate(resourceUrl string, resource crawler.Resource) error {
-	v.logger.Info("validating resource", "resource", resourceUrl)
+func (v *Validator) validate(resource crawler.Resource, info *crawler.ResourceInfo) error {
+	v.logger.Info("validating resource", "resource", info.Location)
 	version := resource.Version()
 	if version == "" {
 		return errors.New("unexpected or missing 'stac_version' member")
@@ -178,7 +178,7 @@ func (v *Validator) validate(resourceUrl string, resource crawler.Resource) erro
 	coreErr := coreSchema.Validate(map[string]interface{}(resource))
 	if coreErr != nil {
 		if err, ok := coreErr.(*jsonschema.ValidationError); ok {
-			return newValidationError(resourceUrl, resource, err)
+			return newValidationError(info.Location, resource, err)
 		}
 		return coreErr
 	}


### PR DESCRIPTION
Previously, the crawl visitor was only called with the resource location.  This change makes it so the visitor is called with an info object containing the resource location and the entry point location.