### PR TITLE
Allow access to task entry and resource detail

### DIFF
--- a/crawler/queue.go
+++ b/crawler/queue.go
@@ -32,6 +32,20 @@ type Task struct {
 	taskType taskType
 }
 
+func (t *Task) Entry() string {
+	if t.entry == nil {
+		return ""
+	}
+	return t.entry.String()
+}
+
+func (t *Task) Resource() string {
+	if t.resource == nil {
+		return ""
+	}
+	return t.resource.String()
+}
+
 func (t *Task) new(resource *normurl.Locator, taskType taskType) *Task {
 	return &Task{
 		entry:    t.entry,

--- a/crawler/queue_test.go
+++ b/crawler/queue_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestTaskDetail(t *testing.T) {
+	entry, entryErr := normurl.New("https://example.com/")
+	require.NoError(t, entryErr)
+
+	resource, resourceErr := normurl.New("https://example.com/resource")
+	require.NoError(t, resourceErr)
+
+	task := &Task{entry: entry, resource: resource, taskType: resourceTask}
+
+	assert.Equal(t, "https://example.com/", task.Entry())
+	assert.Equal(t, "https://example.com/resource", task.Resource())
+}
+
 func TestTaskMarshalJSON(t *testing.T) {
 	entry, entryErr := normurl.New("https://example.com/")
 	require.NoError(t, entryErr)


### PR DESCRIPTION
This adds getters for the task entry and resource as strings.