### PR TITLE
Core types and extensions

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -1,0 +1,50 @@
+package stac
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+type Asset struct {
+	Type        string           `json:"type,omitempty"`
+	Href        string           `json:"href"`
+	Title       string           `json:"title,omitempty"`
+	Description string           `json:"description,omitempty"`
+	Created     string           `json:"created,omitempty"`
+	Roles       []string         `json:"roles,omitempty"`
+	Extensions  []AssetExtension `json:"-"`
+}
+
+var _ json.Marshaler = (*Asset)(nil)
+
+type AssetExtension interface {
+	Apply(*Asset)
+	URI() string
+}
+
+func (asset Asset) MarshalJSON() ([]byte, error) {
+	assetMap := map[string]any{}
+	decoder, decoderErr := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &assetMap,
+	})
+	if decoderErr != nil {
+		return nil, decoderErr
+	}
+
+	decodeErr := decoder.Decode(asset)
+	if decodeErr != nil {
+		return nil, decodeErr
+	}
+
+	for _, extension := range asset.Extensions {
+		extension.Apply(&asset)
+		if decodeErr := decoder.Decode(extension); decodeErr != nil {
+			return nil, fmt.Errorf("trouble encoding JSON for %s asset: %w", extension.URI(), decodeErr)
+		}
+	}
+
+	return json.Marshal(assetMap)
+}

--- a/asset_test.go
+++ b/asset_test.go
@@ -1,0 +1,57 @@
+package stac_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/planetlabs/go-stac"
+	"github.com/planetlabs/go-stac/extensions/pl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssetMarshal(t *testing.T) {
+	asset := &stac.Asset{
+		Title: "An Image",
+		Href:  "https://example.com/image.tif",
+		Type:  "image/tiff",
+		Roles: []string{"data", "reflectance"},
+	}
+
+	data, err := json.Marshal(asset)
+	require.Nil(t, err)
+
+	expected := `{
+		"title": "An Image",
+		"href": "https://example.com/image.tif",
+		"type": "image/tiff",
+		"roles": ["data", "reflectance"]
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}
+
+func TestAssetExtendedMarshal(t *testing.T) {
+	asset := &stac.Asset{
+		Href: "https://example.com/image.tif",
+		Type: "image/tiff",
+		Extensions: []stac.AssetExtension{
+			&pl.Asset{
+				AssetType:  "ortho_analytic_4b_sr",
+				BundleType: "analytic_sr_udm2",
+			},
+		},
+	}
+
+	data, err := json.Marshal(asset)
+	require.Nil(t, err)
+
+	expected := `{
+		"href": "https://example.com/image.tif",
+		"type": "image/tiff",
+		"pl:asset_type": "ortho_analytic_4b_sr",
+		"pl:bundle_type": "analytic_sr_udm2"
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}

--- a/catalog.go
+++ b/catalog.go
@@ -1,0 +1,38 @@
+package stac
+
+import (
+	"encoding/json"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+type Catalog struct {
+	Version     string   `json:"stac_version"`
+	Id          string   `json:"id"`
+	Title       string   `json:"title,omitempty"`
+	Description string   `json:"description"`
+	Links       []*Link  `json:"links"`
+	ConformsTo  []string `json:"conformsTo,omitempty"`
+}
+
+var _ json.Marshaler = (*Catalog)(nil)
+
+func (catalog Catalog) MarshalJSON() ([]byte, error) {
+	collectionMap := map[string]any{
+		"type": "Catalog",
+	}
+	decoder, decoderErr := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &collectionMap,
+	})
+	if decoderErr != nil {
+		return nil, decoderErr
+	}
+
+	decodeErr := decoder.Decode(catalog)
+	if decodeErr != nil {
+		return nil, decodeErr
+	}
+
+	return json.Marshal(collectionMap)
+}

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -1,0 +1,40 @@
+package stac_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/planetlabs/go-stac"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatalogMarshal(t *testing.T) {
+	catalog := &stac.Catalog{
+		Version:     "1.0.0",
+		Id:          "catalog-id",
+		Description: "Test Catalog",
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/catalog", Rel: "self", Type: "application/json"},
+		},
+	}
+
+	data, err := json.Marshal(catalog)
+	require.Nil(t, err)
+
+	expected := `{
+		"type": "Catalog",
+		"id": "catalog-id",
+		"description": "Test Catalog",
+		"links": [
+			{
+				"href": "https://example.com/stac/catalog",
+				"rel": "self",
+				"type": "application/json"
+			}
+		],
+		"stac_version": "1.0.0"
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}

--- a/collection.go
+++ b/collection.go
@@ -1,0 +1,68 @@
+package stac
+
+import (
+	"encoding/json"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+type Collection struct {
+	Version     string            `json:"stac_version"`
+	Id          string            `json:"id"`
+	Title       string            `json:"title,omitempty"`
+	Description string            `json:"description"`
+	Keywords    []string          `json:"keywords,omitempty"`
+	License     string            `json:"license"`
+	Providers   []*Provider       `json:"providers,omitempty"`
+	Extent      *Extent           `json:"extent"`
+	Summaries   map[string]any    `json:"summaries,omitempty"`
+	Links       []*Link           `json:"links"`
+	Assets      map[string]*Asset `json:"assets,omitempty"`
+}
+
+type Provider struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description,omitempty"`
+	Roles       []string `json:"roles,omitempty"`
+	Url         string   `json:"url,omitempty"`
+}
+
+type Extent struct {
+	Spatial  *SpatialExtent  `json:"spatial,omitempty"`
+	Temporal *TemporalExtent `json:"temporal,omitempty"`
+}
+
+type SpatialExtent struct {
+	Bbox [][]float64 `json:"bbox"`
+}
+
+type TemporalExtent struct {
+	Interval [][]any `json:"interval"`
+}
+
+var _ json.Marshaler = (*Collection)(nil)
+
+func (collection Collection) MarshalJSON() ([]byte, error) {
+	collectionMap := map[string]any{
+		"type": "Collection",
+	}
+	decoder, decoderErr := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &collectionMap,
+	})
+	if decoderErr != nil {
+		return nil, decoderErr
+	}
+
+	decodeErr := decoder.Decode(collection)
+	if decodeErr != nil {
+		return nil, decodeErr
+	}
+
+	return json.Marshal(collectionMap)
+}
+
+type CollectionsList struct {
+	Collections []*Collection `json:"collections"`
+	Links       []*Link       `json:"links"`
+}

--- a/collection_test.go
+++ b/collection_test.go
@@ -1,0 +1,54 @@
+package stac_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/planetlabs/go-stac"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectionMarshal(t *testing.T) {
+	collection := &stac.Collection{
+		Version:     "1.0.0",
+		Id:          "collection-id",
+		Description: "Test Collection",
+		License:     "various",
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/collections/collection-id", Rel: "self", Type: "application/json"},
+		},
+		Extent: &stac.Extent{
+			Spatial: &stac.SpatialExtent{
+				Bbox: [][]float64{{-180, -90, 180, 90}},
+			},
+		},
+	}
+
+	data, err := json.Marshal(collection)
+	require.Nil(t, err)
+
+	expected := `{
+		"type": "Collection",
+		"id": "collection-id",
+		"description": "Test Collection",
+		"extent": {
+			"spatial": {
+				"bbox": [
+					[-180, -90, 180, 90]
+				]
+			}
+		},
+		"license": "various",
+		"links": [
+			{
+				"href": "https://example.com/stac/collections/collection-id",
+				"rel": "self",
+				"type": "application/json"
+			}
+		],
+		"stac_version": "1.0.0"
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}

--- a/extensions/pl/pl.go
+++ b/extensions/pl/pl.go
@@ -1,0 +1,39 @@
+package pl
+
+import "github.com/planetlabs/go-stac"
+
+const extensionUri = "https://planetlabs.github.io/stac-extension/v1.0.0-beta.1/schema.json"
+
+type Asset struct {
+	AssetType  string `json:"pl:asset_type,omitempty"`
+	BundleType string `json:"pl:bundle_type,omitempty"`
+}
+
+var _ stac.AssetExtension = (*Asset)(nil)
+
+func (*Asset) URI() string {
+	return extensionUri
+}
+
+func (*Asset) Apply(*stac.Asset) {}
+
+type Item struct {
+	ItemType           string   `json:"pl:item_type,omitempty"`
+	PixelResolution    float64  `json:"pl:pixel_resolution,omitempty"`
+	PublishingStage    string   `json:"pl:publishing_stage,omitempty"`
+	QualityCategory    string   `json:"pl:quality_category,omitempty"`
+	StripId            string   `json:"pl:strip_id,omitempty"`
+	BlackFill          *float64 `json:"pl:black_fill,omitempty"`
+	ClearPercent       *float64 `json:"pl:clear_percent,omitempty"`
+	GridCell           *int     `json:"pl:grid_cell,omitempty"`
+	GroundControl      *bool    `json:"pl:ground_control,omitempty"`
+	GroundControlRatio *float64 `json:"pl:ground_control_ratio,omitempty"`
+}
+
+var _ stac.ItemExtension = (*Item)(nil)
+
+func (*Item) URI() string {
+	return extensionUri
+}
+
+func (*Item) Apply(*stac.Item) {}

--- a/extensions/pl/pl_test.go
+++ b/extensions/pl/pl_test.go
@@ -1,0 +1,91 @@
+package pl_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/planetlabs/go-stac"
+	"github.com/planetlabs/go-stac/extensions/pl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestItemExtendedMarshal(t *testing.T) {
+	groundControlRatio := 0.5
+
+	item := &stac.Item{
+		Version: "1.0.0",
+		Id:      "item-id",
+		Geometry: map[string]any{
+			"type":        "Point",
+			"coordinates": []float64{0, 0},
+		},
+		Properties: map[string]any{
+			"test": "value",
+		},
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/item-id", Rel: "self"},
+		},
+		Assets: map[string]*stac.Asset{
+			"thumbnail": {
+				Title: "Thumbnail",
+				Href:  "https://example.com/stac/item-id/thumb.png",
+				Type:  "image/png",
+				Extensions: []stac.AssetExtension{
+					&pl.Asset{
+						AssetType: "visual",
+					},
+				},
+			},
+		},
+		Extensions: []stac.ItemExtension{
+			&pl.Item{
+				ItemType:           "PSScene",
+				PixelResolution:    3,
+				QualityCategory:    "test",
+				StripId:            "123",
+				GroundControlRatio: &groundControlRatio,
+			},
+		},
+	}
+
+	data, err := json.Marshal(item)
+	require.Nil(t, err)
+
+	expected := `{
+		"type": "Feature",
+		"stac_version": "1.0.0",
+		"id": "item-id",
+		"geometry": {
+			"type": "Point",
+			"coordinates": [0, 0]
+		},
+		"properties": {
+			"test": "value",
+			"pl:item_type": "PSScene",
+			"pl:pixel_resolution": 3,
+			"pl:quality_category": "test",
+			"pl:strip_id": "123",
+			"pl:ground_control_ratio": 0.5
+		},
+		"links": [
+			{
+				"rel": "self",
+				"href": "https://example.com/stac/item-id"
+			}
+		],
+		"assets": {
+			"thumbnail": {
+				"title": "Thumbnail",
+				"href": "https://example.com/stac/item-id/thumb.png",
+				"type": "image/png",
+				"pl:asset_type": "visual"
+			}
+		},
+		"stac_extensions": [
+			"https://planetlabs.github.io/stac-extension/v1.0.0-beta.1/schema.json"
+		]
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}

--- a/extensions/view/view.go
+++ b/extensions/view/view.go
@@ -1,0 +1,21 @@
+package view
+
+import "github.com/planetlabs/go-stac"
+
+const extensionUri = "https://stac-extensions.github.io/view/v1.0.0/schema.json"
+
+type Item struct {
+	OffNadir       *float64 `json:"view:off_nadir,omitempty"`
+	IncidenceAngle *float64 `json:"view:incidence_angle,omitempty"`
+	Azimuth        *float64 `json:"view:azimuth,omitempty"`
+	SunAzimuth     *float64 `json:"view:sun_azimuth,omitempty"`
+	SunElevation   *float64 `json:"view:sun_elevation,omitempty"`
+}
+
+var _ stac.ItemExtension = (*Item)(nil)
+
+func (*Item) URI() string {
+	return extensionUri
+}
+
+func (*Item) Apply(*stac.Item) {}

--- a/extensions/view/view_test.go
+++ b/extensions/view/view_test.go
@@ -1,0 +1,83 @@
+package view_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/planetlabs/go-stac"
+	"github.com/planetlabs/go-stac/extensions/view"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestItemExtendedMarshal(t *testing.T) {
+	offNadir := 12.3
+	sunAzimuth := 145.4
+	sunElevation := 17.7
+
+	item := &stac.Item{
+		Version: "1.0.0",
+		Id:      "item-id",
+		Geometry: map[string]any{
+			"type":        "Point",
+			"coordinates": []float64{0, 0},
+		},
+		Properties: map[string]any{
+			"test": "value",
+		},
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/item-id", Rel: "self"},
+		},
+		Assets: map[string]*stac.Asset{
+			"thumbnail": {
+				Title: "Thumbnail",
+				Href:  "https://example.com/stac/item-id/thumb.png",
+				Type:  "image/png",
+			},
+		},
+		Extensions: []stac.ItemExtension{
+			&view.Item{
+				OffNadir:     &offNadir,
+				SunAzimuth:   &sunAzimuth,
+				SunElevation: &sunElevation,
+			},
+		},
+	}
+
+	data, err := json.Marshal(item)
+	require.Nil(t, err)
+
+	expected := `{
+		"type": "Feature",
+		"stac_version": "1.0.0",
+		"id": "item-id",
+		"geometry": {
+			"type": "Point",
+			"coordinates": [0, 0]
+		},
+		"properties": {
+			"test": "value",
+			"view:off_nadir": 12.3,
+			"view:sun_azimuth": 145.4,
+			"view:sun_elevation": 17.7
+		},
+		"links": [
+			{
+				"rel": "self",
+				"href": "https://example.com/stac/item-id"
+			}
+		],
+		"assets": {
+			"thumbnail": {
+				"title": "Thumbnail",
+				"href": "https://example.com/stac/item-id/thumb.png",
+				"type": "image/png"
+			}
+		},
+		"stac_extensions": [
+			"https://stac-extensions.github.io/view/v1.0.0/schema.json"
+		]
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/go-logr/zapr v1.2.3
 	github.com/google/go-github/v45 v45.2.0
 	github.com/hashicorp/go-retryablehttp v0.7.2
+	github.com/mitchellh/mapstructure v1.5.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.2.0
 	github.com/schollz/progressbar/v3 v3.13.0
 	github.com/stretchr/testify v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWV
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/item.go
+++ b/item.go
@@ -1,0 +1,115 @@
+package stac
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/mitchellh/mapstructure"
+)
+
+var coreItemProperties = map[string]bool{
+	"datetime":      true,
+	"created":       true,
+	"updated":       true,
+	"gsd":           true,
+	"constellation": true,
+	"instruments":   true,
+	"platform":      true,
+}
+
+func IsCoreItemProperty(prop string) bool {
+	return coreItemProperties[prop]
+}
+
+type Item struct {
+	Version    string            `json:"stac_version"`
+	Id         string            `json:"id"`
+	Geometry   any               `json:"geometry"`
+	Bbox       []float64         `json:"bbox,omitempty"`
+	Properties map[string]any    `json:"properties"`
+	Links      []*Link           `json:"links"`
+	Assets     map[string]*Asset `json:"assets"`
+	Collection string            `json:"collection,omitempty"`
+	Extensions []ItemExtension   `json:"-"`
+}
+
+var _ json.Marshaler = (*Item)(nil)
+
+type ItemExtension interface {
+	Apply(*Item)
+	URI() string
+}
+
+func PopulateExtensionFromProperties(extension ItemExtension, properties map[string]any) error {
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  extension,
+	})
+	if err != nil {
+		return err
+	}
+
+	return decoder.Decode(properties)
+}
+
+func (item Item) MarshalJSON() ([]byte, error) {
+	itemMap := map[string]any{"type": "Feature"}
+	decoder, decoderErr := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &itemMap,
+	})
+	if decoderErr != nil {
+		return nil, decoderErr
+	}
+
+	decodeErr := decoder.Decode(item)
+	if decodeErr != nil {
+		return nil, decodeErr
+	}
+
+	propDecoder, propDecoderErr := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		TagName: "json",
+		Result:  &item.Properties,
+	})
+	if propDecoderErr != nil {
+		return nil, propDecoderErr
+	}
+
+	extensionUris := []string{}
+	lookup := map[string]bool{}
+
+	for _, asset := range item.Assets {
+		for _, extension := range asset.Extensions {
+			uri := extension.URI()
+			if !lookup[uri] {
+				extensionUris = append(extensionUris, uri)
+				lookup[uri] = true
+			}
+		}
+	}
+
+	for _, extension := range item.Extensions {
+		extension.Apply(&item)
+		uri := extension.URI()
+		if !lookup[uri] {
+			extensionUris = append(extensionUris, uri)
+			lookup[uri] = true
+		}
+
+		if decodeErr := propDecoder.Decode(extension); decodeErr != nil {
+			return nil, fmt.Errorf("trouble encoding JSON for %s item properties: %w", uri, decodeErr)
+		}
+	}
+
+	if len(extensionUris) > 0 {
+		itemMap["stac_extensions"] = extensionUris
+	}
+
+	return json.Marshal(itemMap)
+}
+
+type ItemsList struct {
+	Type  string  `json:"type"`
+	Items []*Item `json:"features"`
+	Links []*Link `json:"links,omitempty"`
+}

--- a/item_test.go
+++ b/item_test.go
@@ -1,0 +1,65 @@
+package stac_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/planetlabs/go-stac"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestItemMarshal(t *testing.T) {
+	item := &stac.Item{
+		Version: "1.0.0",
+		Id:      "item-id",
+		Geometry: map[string]any{
+			"type":        "Point",
+			"coordinates": []float64{0, 0},
+		},
+		Properties: map[string]any{
+			"test": "value",
+		},
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/item-id", Rel: "self"},
+		},
+		Assets: map[string]*stac.Asset{
+			"thumbnail": {
+				Title: "Thumbnail",
+				Href:  "https://example.com/stac/item-id/thumb.png",
+				Type:  "image/png",
+			},
+		},
+	}
+
+	data, err := json.Marshal(item)
+	require.Nil(t, err)
+
+	expected := `{
+		"type": "Feature",
+		"stac_version": "1.0.0",
+		"id": "item-id",
+		"geometry": {
+			"type": "Point",
+			"coordinates": [0, 0]
+		},
+		"properties": {
+			"test": "value"
+		},
+		"links": [
+			{
+				"rel": "self",
+				"href": "https://example.com/stac/item-id"
+			}
+		],
+		"assets": {
+			"thumbnail": {
+				"title": "Thumbnail",
+				"href": "https://example.com/stac/item-id/thumb.png",
+				"type": "image/png"
+			}
+		}
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}

--- a/link.go
+++ b/link.go
@@ -1,0 +1,8 @@
+package stac
+
+type Link struct {
+	Href  string `json:"href"`
+	Rel   string `json:"rel"`
+	Type  string `json:"type,omitempty"`
+	Title string `json:"title,omitempty"`
+}


### PR DESCRIPTION
This adds structs for the core STAC types and makes it possible to extend them (items and asset extensions only at the moment).