### PR TITLE
New artifact names

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,11 +12,9 @@ builds:
       - darwin
 archives:
   - name_template: >-
-      {{ .ProjectName }}_
-      {{- title .Os }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}i386
-      {{- else }}{{ .Arch }}{{ end }}
+      {{ .ProjectName }}-
+      {{- .Os }}-
+      {{- .Arch }}
 dockers:
   - image_templates:
       - "ghcr.io/planetlabs/go-stac:{{ .Tag }}"


### PR DESCRIPTION
This updates the release artifact names to use the `GOOS` and `GOARCH` values directly.