### PR TITLE
Use minor, rather than patch golang version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/planetlabs/go-stac
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/dlclark/regexp2 v1.10.0


### PR DESCRIPTION
This is a bit new to me, but currently, the `go.mod` file uses 1.21.0, pinning to a patch rather than a minor version. I believe this in turn requires all dependent code to specify a patch version (I found this issue because my `go mod tidy` in dependent repos was adding a patch to the semver).

Specifying only the major and minor version can offer broader compatibility with different patch versions, and I think is OK here.