### PR TITLE
validator: return validation error for extension validation errors

### DIFF
--- a/validator/validator.go
+++ b/validator/validator.go
@@ -197,6 +197,9 @@ func (v *Validator) validate(resource crawler.Resource, info *crawler.ResourceIn
 		}
 		extensionErr := extensionSchema.Validate(map[string]interface{}(resource))
 		if extensionErr != nil {
+			if err, ok := extensionErr.(*jsonschema.ValidationError); ok {
+				return newValidationError(info.Location, resource, err)
+			}
 			return extensionErr
 		}
 	}


### PR DESCRIPTION
### Description

When validating schema extensions the validator result isn't very helpful. Here is an example error:

```
validation failed: jsonschema: '' does not validate with https://stac-extensions.github.io/raster/v1.1.0/schema.json#/oneOf: oneOf failed
```

It would be useful to receive the report for the entire validation, especially the failed resource. With this change we should see the full validation result - example:

```
invalid collection: /path/to/failed/collection.json
[I#] [S#] doesn't validate with https://stac-extensions.github.io/raster/v1.1.0/schema.json#
  [I#] [S#/oneOf] oneOf failed
    [I#] [S#/oneOf/0/allOf/0] allOf failed
      [I#] [S#/oneOf/0/allOf/0]
        [I#] [S#/oneOf/0/allOf/0/required] missing properties: 'assets'
        [I#/type] [S#/oneOf/0/allOf/0/properties/type/const] value must be "Feature"
    [I#] [S#/oneOf/1/allOf/0] allOf failed
      [I#/item_assets/acd] [S#/oneOf/1/allOf/0/properties/item_assets/additionalProperties/$ref] doesn't validate with '/definitions/assetfields'
        [I#/item_assets/acd/raster:bands] [S#/definitions/assetfields/properties/raster:bands/$ref] doesn't validate with '/definitions/bands'
          [I#/item_assets/acd/raster:bands/0/nodata] [S#/definitions/bands/items/properties/nodata/oneOf] oneOf failed
            [I#/item_assets/acd/raster:bands/0/nodata] [S#/definitions/bands/items/properties/nodata/oneOf/0/type] expected number, but got string
            [I#/item_assets/acd/raster:bands/0/nodata] [S#/definitions/bands/items/properties/nodata/oneOf/1/enum] value must be one of "nan", "inf", "-inf"
```

This is accomplished by ensuring that the extension error is actually a `jsonschema.ValidationError` and then pass this to the `newValidationError` func to preserve context.

If for some reason we can't parse the error as expected, we go ahead and return it as usual.

