### PR TITLE
Add support for the authentication extension

### DIFF
--- a/collection.go
+++ b/collection.go
@@ -95,6 +95,19 @@ func (collection Collection) MarshalJSON() ([]byte, error) {
 		}
 	}
 
+	links, linkExtensionUris, err := EncodeLinks(collection.Links)
+	if err != nil {
+		return nil, err
+	}
+	collectionMap["links"] = links
+
+	for _, uri := range linkExtensionUris {
+		if !lookup[uri] {
+			extensionUris = append(extensionUris, uri)
+			lookup[uri] = true
+		}
+	}
+
 	SetExtensionUris(collectionMap, extensionUris)
 	return json.Marshal(collectionMap)
 }
@@ -130,6 +143,10 @@ func (collection *Collection) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("decoding error for %s: %w", uri, err)
 		}
 		collection.Extensions = append(collection.Extensions, extension)
+	}
+
+	if err := decodeExtendedLinks(collectionMap, collection.Links, extensionUris); err != nil {
+		return err
 	}
 
 	return nil

--- a/extensions/auth/auth.go
+++ b/extensions/auth/auth.go
@@ -1,0 +1,159 @@
+package auth
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/mitchellh/mapstructure"
+	"github.com/planetlabs/go-stac"
+)
+
+const (
+	extensionUri     = "https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+	extensionPattern = `https://stac-extensions.github.io/authentication/v1\..*/schema.json`
+	schemesKey       = "auth:schemes"
+	refsKey          = "auth:refs"
+)
+
+func init() {
+	r := regexp.MustCompile(extensionPattern)
+
+	stac.RegisterCollectionExtension(r, func() stac.Extension { return &Collection{} })
+	stac.RegisterCatalogExtension(r, func() stac.Extension { return &Catalog{} })
+	stac.RegisterAssetExtension(r, func() stac.Extension { return &Asset{} })
+	stac.RegisterLinkExtension(r, func() stac.Extension { return &Link{} })
+}
+
+type Collection struct {
+	Schemes map[string]*Scheme
+}
+
+var _ stac.Extension = (*Collection)(nil)
+
+func (*Collection) URI() string {
+	return extensionUri
+}
+
+func (e *Collection) Encode(collectionMap map[string]any) error {
+	collectionMap[schemesKey] = e.Schemes
+	return nil
+}
+
+func (e *Collection) Decode(collectionMap map[string]any) error {
+	schemes, err := decodeSchemes(collectionMap)
+	if err != nil {
+		return err
+	}
+	e.Schemes = schemes
+	return nil
+}
+
+type Catalog struct {
+	Schemes map[string]*Scheme
+}
+
+var _ stac.Extension = (*Catalog)(nil)
+
+func (*Catalog) URI() string {
+	return extensionUri
+}
+
+func (e *Catalog) Encode(catalogMap map[string]any) error {
+	catalogMap[schemesKey] = e.Schemes
+	return nil
+}
+
+func (e *Catalog) Decode(catalogMap map[string]any) error {
+	schemes, err := decodeSchemes(catalogMap)
+	if err != nil {
+		return err
+	}
+	e.Schemes = schemes
+	return nil
+}
+
+func decodeSchemes(data map[string]any) (map[string]*Scheme, error) {
+	schemesValue, ok := data[schemesKey]
+	if !ok {
+		return nil, nil
+	}
+
+	schemesMap, ok := schemesValue.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected %s to be an map[string]any, got %t", schemesKey, schemesValue)
+	}
+
+	schemes := map[string]*Scheme{}
+	for key, schemeValue := range schemesMap {
+		schemeMap, ok := schemeValue.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("expected scheme to be a map[string]any, got %t", schemeValue)
+		}
+		scheme := &Scheme{}
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			TagName: "json",
+			Result:  scheme,
+		})
+		if err != nil {
+			return nil, err
+		}
+		if err := decoder.Decode(schemeMap); err != nil {
+			return nil, err
+		}
+
+		schemes[key] = scheme
+	}
+	return schemes, nil
+}
+
+type Scheme struct {
+	Type             string         `json:"type"`
+	Description      string         `json:"description,omitempty"`
+	Name             string         `json:"name,omitempty"`
+	In               string         `json:"in,omitempty"`
+	Scheme           string         `json:"scheme,omitempty"`
+	Flows            map[string]any `json:"flows,omitempty"`
+	OpenIdConnectUrl string         `json:"openIdConnectUrl,omitempty"`
+}
+
+type Asset struct {
+	Refs []string `json:"auth:refs,omitempty"`
+}
+
+var _ stac.Extension = (*Asset)(nil)
+
+func (*Asset) URI() string {
+	return extensionUri
+}
+
+func (e *Asset) Encode(assetMap map[string]any) error {
+	return stac.EncodeExtendedMap(e, assetMap)
+}
+
+func (e *Asset) Decode(assetMap map[string]any) error {
+	if _, ok := assetMap[refsKey]; !ok {
+		return stac.ErrExtensionDoesNotApply
+	}
+	return stac.DecodeExtendedMap(e, assetMap)
+}
+
+type Link struct {
+	Refs []string `json:"auth:refs,omitempty"`
+}
+
+var _ stac.Extension = (*Link)(nil)
+
+func (*Link) URI() string {
+	return extensionUri
+}
+
+func (e *Link) Encode(linkMap map[string]any) error {
+	return stac.EncodeExtendedMap(e, linkMap)
+}
+
+func (e *Link) Decode(linkMap map[string]any) error {
+	if _, ok := linkMap[refsKey]; !ok {
+		return stac.ErrExtensionDoesNotApply
+	}
+	return stac.DecodeExtendedMap(e, linkMap)
+}

--- a/extensions/auth/auth_test.go
+++ b/extensions/auth/auth_test.go
@@ -1,0 +1,800 @@
+package auth_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/planetlabs/go-stac"
+	"github.com/planetlabs/go-stac/extensions/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectionExtendedMarshal(t *testing.T) {
+	collection := &stac.Collection{
+		Version:     "1.0.0",
+		Id:          "collection-id",
+		Description: "Test Collection",
+		License:     "various",
+		Extent: &stac.Extent{
+			Spatial: &stac.SpatialExtent{
+				Bbox: [][]float64{{-180, -90, 180, 90}},
+			},
+		},
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/collections/collection-id", Rel: "self", Type: "application/json"},
+		},
+		Extensions: []stac.Extension{
+			&auth.Collection{
+				Schemes: map[string]*auth.Scheme{
+					"openid": {
+						Type:             "openIdConnect",
+						Description:      "Test auth configuration",
+						OpenIdConnectUrl: "https://example.com/auth/.well-known/openid-configuration",
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(collection)
+	require.NoError(t, err)
+
+	expected := `{
+		"type": "Collection",
+		"id": "collection-id",
+		"description": "Test Collection",
+		"extent": {
+			"spatial": {
+				"bbox": [
+					[-180, -90, 180, 90]
+				]
+			}
+		},
+		"license": "various",
+		"auth:schemes": {
+			"openid": {
+				"type": "openIdConnect",
+				"description": "Test auth configuration",
+				"openIdConnectUrl": "https://example.com/auth/.well-known/openid-configuration"
+			}
+		},
+		"links": [
+			{
+				"href": "https://example.com/stac/collections/collection-id",
+				"rel": "self",
+				"type": "application/json"
+			}
+		],
+		"stac_extensions": [
+			"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+		],
+		"stac_version": "1.0.0"
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}
+
+func TestCollectionLinkExtendedMarshal(t *testing.T) {
+	collection := &stac.Collection{
+		Version:     "1.0.0",
+		Id:          "collection-id",
+		Description: "Test Collection",
+		License:     "various",
+		Extent: &stac.Extent{
+			Spatial: &stac.SpatialExtent{
+				Bbox: [][]float64{{-180, -90, 180, 90}},
+			},
+		},
+		Links: []*stac.Link{
+			{
+				Href: "https://example.com/stac/collections/collection-id",
+				Rel:  "self",
+				Type: "application/json",
+				Extensions: []stac.Extension{
+					&auth.Link{
+						Refs: []string{"openid"},
+					},
+				},
+			},
+		},
+		Extensions: []stac.Extension{
+			&auth.Collection{
+				Schemes: map[string]*auth.Scheme{
+					"openid": {
+						Type:             "openIdConnect",
+						Description:      "Test auth configuration",
+						OpenIdConnectUrl: "https://example.com/auth/.well-known/openid-configuration",
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(collection)
+	require.NoError(t, err)
+
+	expected := `{
+		"type": "Collection",
+		"id": "collection-id",
+		"description": "Test Collection",
+		"extent": {
+			"spatial": {
+				"bbox": [
+					[-180, -90, 180, 90]
+				]
+			}
+		},
+		"license": "various",
+		"auth:schemes": {
+			"openid": {
+				"type": "openIdConnect",
+				"description": "Test auth configuration",
+				"openIdConnectUrl": "https://example.com/auth/.well-known/openid-configuration"
+			}
+		},
+		"links": [
+			{
+				"href": "https://example.com/stac/collections/collection-id",
+				"rel": "self",
+				"type": "application/json",
+				"auth:refs": ["openid"]
+			}
+		],
+		"stac_extensions": [
+			"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+		],
+		"stac_version": "1.0.0"
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}
+
+func TestCollectionExtendedUnmarshal(t *testing.T) {
+	data := []byte(`{
+		"type": "Collection",
+		"id": "collection-id",
+		"description": "Test Collection",
+		"extent": {
+			"spatial": {
+				"bbox": [
+					[-180, -90, 180, 90]
+				]
+			}
+		},
+		"license": "various",
+		"auth:schemes": {
+			"openid": {
+				"type": "openIdConnect",
+				"openIdConnectUrl": "https://example.com/auth/.well-known/openid-configuration"
+			}
+		},
+		"links": [
+			{
+				"href": "https://example.com/stac/collections/collection-id",
+				"rel": "self",
+				"type": "application/json"
+			}
+		],
+		"stac_extensions": [
+			"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+		],
+		"stac_version": "1.0.0"
+	}`)
+
+	collection := &stac.Collection{}
+	require.NoError(t, json.Unmarshal(data, collection))
+
+	expected := &stac.Collection{
+		Version:     "1.0.0",
+		Id:          "collection-id",
+		Description: "Test Collection",
+		License:     "various",
+		Extent: &stac.Extent{
+			Spatial: &stac.SpatialExtent{
+				Bbox: [][]float64{{-180, -90, 180, 90}},
+			},
+		},
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/collections/collection-id", Rel: "self", Type: "application/json"},
+		},
+		Extensions: []stac.Extension{
+			&auth.Collection{
+				Schemes: map[string]*auth.Scheme{
+					"openid": {
+						Type:             "openIdConnect",
+						OpenIdConnectUrl: "https://example.com/auth/.well-known/openid-configuration",
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, collection)
+}
+
+func TestCollectionLinkExtendedUnmarshal(t *testing.T) {
+	data := []byte(`{
+		"type": "Collection",
+		"id": "collection-id",
+		"description": "Test Collection",
+		"extent": {
+			"spatial": {
+				"bbox": [
+					[-180, -90, 180, 90]
+				]
+			}
+		},
+		"license": "various",
+		"auth:schemes": {
+			"openid": {
+				"type": "openIdConnect",
+				"openIdConnectUrl": "https://example.com/auth/.well-known/openid-configuration"
+			}
+		},
+		"links": [
+			{
+				"href": "https://example.com/stac/collections/collection-id",
+				"rel": "self",
+				"type": "application/json",
+				"auth:refs": ["openid"]
+			}
+		],
+		"stac_extensions": [
+			"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+		],
+		"stac_version": "1.0.0"
+	}`)
+
+	collection := &stac.Collection{}
+	require.NoError(t, json.Unmarshal(data, collection))
+
+	expected := &stac.Collection{
+		Version:     "1.0.0",
+		Id:          "collection-id",
+		Description: "Test Collection",
+		License:     "various",
+		Extent: &stac.Extent{
+			Spatial: &stac.SpatialExtent{
+				Bbox: [][]float64{{-180, -90, 180, 90}},
+			},
+		},
+		Links: []*stac.Link{
+			{
+				Href: "https://example.com/stac/collections/collection-id",
+				Rel:  "self",
+				Type: "application/json",
+				Extensions: []stac.Extension{
+					&auth.Link{
+						Refs: []string{"openid"},
+					},
+				},
+			},
+		},
+		Extensions: []stac.Extension{
+			&auth.Collection{
+				Schemes: map[string]*auth.Scheme{
+					"openid": {
+						Type:             "openIdConnect",
+						OpenIdConnectUrl: "https://example.com/auth/.well-known/openid-configuration",
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, collection)
+}
+
+func TestCatalogExtendedMarshal(t *testing.T) {
+	catalog := &stac.Catalog{
+		Version:     "1.0.0",
+		Id:          "catalog-id",
+		Description: "Test Catalog",
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/catalog-id", Rel: "self", Type: "application/json"},
+		},
+		Extensions: []stac.Extension{
+			&auth.Catalog{
+				Schemes: map[string]*auth.Scheme{
+					"oauth": {
+						Type:        "oauth2",
+						Description: "Test auth configuration",
+						Flows: map[string]any{
+							"authorizationUrl": "https://example.com/oauth/authorize",
+							"tokenUrl":         "https://example.com/oauth/token",
+							"scopes":           []any{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(catalog)
+	require.NoError(t, err)
+
+	expected := `{
+		"type": "Catalog",
+		"id": "catalog-id",
+		"description": "Test Catalog",
+		"auth:schemes": {
+			"oauth": {
+				"type": "oauth2",
+				"description": "Test auth configuration",
+				"flows": {
+					"authorizationUrl": "https://example.com/oauth/authorize",
+					"tokenUrl": "https://example.com/oauth/token",
+					"scopes": []
+				}
+			}
+		},
+		"links": [
+			{
+				"href": "https://example.com/stac/catalog-id",
+				"rel": "self",
+				"type": "application/json"
+			}
+		],
+		"stac_extensions": [
+			"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+		],
+		"stac_version": "1.0.0"
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}
+
+func TestCatalogLinkExtendedMarshal(t *testing.T) {
+	catalog := &stac.Catalog{
+		Version:     "1.0.0",
+		Id:          "catalog-id",
+		Description: "Test Catalog",
+		Links: []*stac.Link{
+			{
+				Href: "https://example.com/stac/catalog-id",
+				Rel:  "self",
+				Type: "application/json",
+				Extensions: []stac.Extension{
+					&auth.Link{
+						Refs: []string{"oauth"},
+					},
+				},
+			},
+		},
+		Extensions: []stac.Extension{
+			&auth.Catalog{
+				Schemes: map[string]*auth.Scheme{
+					"oauth": {
+						Type:        "oauth2",
+						Description: "Test auth configuration",
+						Flows: map[string]any{
+							"authorizationUrl": "https://example.com/oauth/authorize",
+							"tokenUrl":         "https://example.com/oauth/token",
+							"scopes":           []any{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(catalog)
+	require.NoError(t, err)
+
+	expected := `{
+		"type": "Catalog",
+		"id": "catalog-id",
+		"description": "Test Catalog",
+		"auth:schemes": {
+			"oauth": {
+				"type": "oauth2",
+				"description": "Test auth configuration",
+				"flows": {
+					"authorizationUrl": "https://example.com/oauth/authorize",
+					"tokenUrl": "https://example.com/oauth/token",
+					"scopes": []
+				}
+			}
+		},
+		"links": [
+			{
+				"href": "https://example.com/stac/catalog-id",
+				"rel": "self",
+				"type": "application/json",
+				"auth:refs": ["oauth"]
+			}
+		],
+		"stac_extensions": [
+			"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+		],
+		"stac_version": "1.0.0"
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}
+
+func TestCatalogExtendedUnmarshal(t *testing.T) {
+	data := []byte(`{
+		"type": "Catalog",
+		"id": "catalog-id",
+		"description": "Test Catalog",
+		"auth:schemes": {
+			"oauth": {
+				"type": "oauth2",
+				"flows": {
+					"authorizationUrl": "https://example.com/oauth/authorize",
+					"tokenUrl": "https://example.com/oauth/token",
+					"scopes": []
+				}
+			}
+		},
+		"links": [
+			{
+				"href": "https://example.com/stac/catalog-id",
+				"rel": "self",
+				"type": "application/json"
+			}
+		],
+		"stac_extensions": [
+			"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+		],
+		"stac_version": "1.0.0"
+	}`)
+
+	catalog := &stac.Catalog{}
+	require.NoError(t, json.Unmarshal(data, catalog))
+
+	expected := &stac.Catalog{
+		Version:     "1.0.0",
+		Id:          "catalog-id",
+		Description: "Test Catalog",
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/catalog-id", Rel: "self", Type: "application/json"},
+		},
+		Extensions: []stac.Extension{
+			&auth.Catalog{
+				Schemes: map[string]*auth.Scheme{
+					"oauth": {
+						Type: "oauth2",
+						Flows: map[string]any{
+							"authorizationUrl": "https://example.com/oauth/authorize",
+							"tokenUrl":         "https://example.com/oauth/token",
+							"scopes":           []any{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, catalog)
+}
+
+func TestCatalogLinkExtendedUnmarshal(t *testing.T) {
+	data := []byte(`{
+		"type": "Catalog",
+		"id": "catalog-id",
+		"description": "Test Catalog",
+		"auth:schemes": {
+			"oauth": {
+				"type": "oauth2",
+				"flows": {
+					"authorizationUrl": "https://example.com/oauth/authorize",
+					"tokenUrl": "https://example.com/oauth/token",
+					"scopes": []
+				}
+			}
+		},
+		"links": [
+			{
+				"href": "https://example.com/stac/catalog-id",
+				"rel": "self",
+				"type": "application/json",
+				"auth:refs": ["oauth"]
+			}
+		],
+		"stac_extensions": [
+			"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+		],
+		"stac_version": "1.0.0"
+	}`)
+
+	catalog := &stac.Catalog{}
+	require.NoError(t, json.Unmarshal(data, catalog))
+
+	expected := &stac.Catalog{
+		Version:     "1.0.0",
+		Id:          "catalog-id",
+		Description: "Test Catalog",
+		Links: []*stac.Link{
+			{
+				Href: "https://example.com/stac/catalog-id",
+				Rel:  "self",
+				Type: "application/json",
+				Extensions: []stac.Extension{
+					&auth.Link{
+						Refs: []string{"oauth"},
+					},
+				},
+			},
+		},
+		Extensions: []stac.Extension{
+			&auth.Catalog{
+				Schemes: map[string]*auth.Scheme{
+					"oauth": {
+						Type: "oauth2",
+						Flows: map[string]any{
+							"authorizationUrl": "https://example.com/oauth/authorize",
+							"tokenUrl":         "https://example.com/oauth/token",
+							"scopes":           []any{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, catalog)
+}
+
+func TestItemAssetExtendedMarshal(t *testing.T) {
+	item := &stac.Item{
+		Version: "1.0.0",
+		Id:      "item-id",
+		Geometry: map[string]any{
+			"type":        "Point",
+			"coordinates": []float64{0, 0},
+		},
+		Properties: map[string]any{
+			"test": "value",
+		},
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/item-id", Rel: "self"},
+		},
+		Assets: map[string]*stac.Asset{
+			"image": {
+				Title: "Image",
+				Href:  "https://example.com/stac/item-id/image.tif",
+				Type:  "image/tif",
+				Extensions: []stac.Extension{
+					&auth.Asset{
+						Refs: []string{"openid"},
+					},
+				},
+			},
+		},
+	}
+
+	data, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	expected := `{
+		"type": "Feature",
+		"stac_version": "1.0.0",
+		"id": "item-id",
+		"geometry": {
+			"type": "Point",
+			"coordinates": [0, 0]
+		},
+		"properties": {
+			"test": "value"
+		},
+		"links": [
+			{
+				"rel": "self",
+				"href": "https://example.com/stac/item-id"
+			}
+		],
+		"assets": {
+			"image": {
+				"title": "Image",
+				"href": "https://example.com/stac/item-id/image.tif",
+				"type": "image/tif",
+				"auth:refs": ["openid"]
+			}
+		},
+		"stac_extensions": [
+			"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+		]
+	}`
+
+	assert.JSONEq(t, expected, string(data))
+}
+
+func TestItemAssetExtendedUnmarshal(t *testing.T) {
+	data := []byte(`{
+			"type": "Feature",
+			"stac_version": "1.0.0",
+			"id": "item-id",
+			"geometry": {
+				"type": "Point",
+				"coordinates": [0, 0]
+			},
+			"properties": {
+				"test": "value"
+			},
+			"links": [
+				{
+					"rel": "self",
+					"href": "https://example.com/stac/item-id"
+				}
+			],
+			"assets": {
+				"image": {
+					"title": "Image",
+					"href": "https://example.com/stac/item-id/image.tif",
+					"type": "image/tif",
+					"auth:refs": ["openid"]
+				}
+			},
+			"stac_extensions": [
+				"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+			]
+    }`)
+
+	item := &stac.Item{}
+	require.NoError(t, json.Unmarshal(data, item))
+
+	expected := &stac.Item{
+		Version: "1.0.0",
+		Id:      "item-id",
+		Geometry: map[string]any{
+			"type":        "Point",
+			"coordinates": []any{float64(0), float64(0)},
+		},
+		Properties: map[string]any{
+			"test": "value",
+		},
+		Links: []*stac.Link{
+			{Href: "https://example.com/stac/item-id", Rel: "self"},
+		},
+		Assets: map[string]*stac.Asset{
+			"image": {
+				Title: "Image",
+				Href:  "https://example.com/stac/item-id/image.tif",
+				Type:  "image/tif",
+				Extensions: []stac.Extension{
+					&auth.Asset{
+						Refs: []string{"openid"},
+					},
+				},
+			},
+		},
+	}
+
+	assert.Equal(t, expected, item)
+}
+
+func TestItemLinkExtendedMarshal(t *testing.T) {
+	item := &stac.Item{
+		Version: "1.0.0",
+		Id:      "item-id",
+		Geometry: map[string]any{
+			"type":        "Point",
+			"coordinates": []float64{0, 0},
+		},
+		Properties: map[string]any{
+			"test": "value",
+		},
+		Links: []*stac.Link{
+			{
+				Href: "https://example.com/stac/item-id", Rel: "self",
+				Extensions: []stac.Extension{
+					&auth.Link{
+						Refs: []string{"openid"},
+					},
+				},
+			},
+		},
+		Assets: map[string]*stac.Asset{
+			"image": {
+				Title: "Image",
+				Href:  "https://example.com/stac/item-id/image.tif",
+				Type:  "image/tif",
+			},
+		},
+	}
+
+	data, err := json.Marshal(item)
+	require.NoError(t, err)
+
+	expected := `{
+		"type": "Feature",
+		"stac_version": "1.0.0",
+		"id": "item-id",
+		"geometry": {
+			"type": "Point",
+			"coordinates": [0, 0]
+		},
+		"properties": {
+			"test": "value"
+		},
+		"links": [
+			{
+				"rel": "self",
+				"href": "https://example.com/stac/item-id",
+				"auth:refs": ["openid"]
+			}
+		],
+		"assets": {
+			"image": {
+				"title": "Image",
+				"href": "https://example.com/stac/item-id/image.tif",
+				"type": "image/tif"
+			}
+		},
+		"stac_extensions": [
+			"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+		]
+}`
+
+	assert.JSONEq(t, expected, string(data))
+}
+
+func TestItemLinkExtendedUnmarshal(t *testing.T) {
+	data := []byte(`{
+			"type": "Feature",
+			"stac_version": "1.0.0",
+			"id": "item-id",
+			"geometry": {
+				"type": "Point",
+				"coordinates": [0, 0]
+			},
+			"properties": {
+				"test": "value"
+			},
+			"links": [
+				{
+					"rel": "self",
+					"href": "https://example.com/stac/item-id",
+					"auth:refs": ["openid"]
+				}
+			],
+			"assets": {
+				"image": {
+					"title": "Image",
+					"href": "https://example.com/stac/item-id/image.tif",
+					"type": "image/tif"
+				}
+			},
+			"stac_extensions": [
+				"https://stac-extensions.github.io/authentication/v1.1.0/schema.json"
+			]
+    }`)
+
+	item := &stac.Item{}
+	require.NoError(t, json.Unmarshal(data, item))
+
+	expected := &stac.Item{
+		Version: "1.0.0",
+		Id:      "item-id",
+		Geometry: map[string]any{
+			"type":        "Point",
+			"coordinates": []any{float64(0), float64(0)},
+		},
+		Properties: map[string]any{
+			"test": "value",
+		},
+		Links: []*stac.Link{
+			{
+				Href: "https://example.com/stac/item-id",
+				Rel:  "self",
+				Extensions: []stac.Extension{
+					&auth.Link{
+						Refs: []string{"openid"},
+					},
+				},
+			},
+		},
+		Assets: map[string]*stac.Asset{
+			"image": {
+				Title: "Image",
+				Href:  "https://example.com/stac/item-id/image.tif",
+				Type:  "image/tif",
+			},
+		},
+	}
+
+	assert.Equal(t, expected, item)
+}

--- a/extensions/eo/eo.go
+++ b/extensions/eo/eo.go
@@ -42,9 +42,9 @@ func (*Asset) URI() string {
 }
 
 func (e *Asset) Encode(assetMap map[string]any) error {
-	return stac.EncodeExtendedAsset(e, assetMap)
+	return stac.EncodeExtendedMap(e, assetMap)
 }
 
 func (e *Asset) Decode(assetMap map[string]any) error {
-	return stac.DecodeExtendedAsset(e, assetMap)
+	return stac.DecodeExtendedMap(e, assetMap)
 }

--- a/extensions/pl/pl.go
+++ b/extensions/pl/pl.go
@@ -38,11 +38,11 @@ func (*Asset) URI() string {
 }
 
 func (e *Asset) Encode(assetMap map[string]any) error {
-	return stac.EncodeExtendedAsset(e, assetMap)
+	return stac.EncodeExtendedMap(e, assetMap)
 }
 
 func (e *Asset) Decode(assetMap map[string]any) error {
-	return stac.DecodeExtendedAsset(e, assetMap)
+	return stac.DecodeExtendedMap(e, assetMap)
 }
 
 type Item struct {

--- a/extensions/raster/raster.go
+++ b/extensions/raster/raster.go
@@ -59,9 +59,9 @@ func (*Asset) URI() string {
 }
 
 func (e *Asset) Encode(assetMap map[string]any) error {
-	return stac.EncodeExtendedAsset(e, assetMap)
+	return stac.EncodeExtendedMap(e, assetMap)
 }
 
 func (e *Asset) Decode(assetMap map[string]any) error {
-	return stac.DecodeExtendedAsset(e, assetMap)
+	return stac.DecodeExtendedMap(e, assetMap)
 }

--- a/link.go
+++ b/link.go
@@ -2,6 +2,7 @@ package stac
 
 import (
 	"encoding/json"
+	"regexp"
 
 	"github.com/mitchellh/mapstructure"
 )
@@ -11,7 +12,50 @@ type Link struct {
 	Rel              string         `mapstructure:"rel"`
 	Type             string         `mapstructure:"type,omitempty"`
 	Title            string         `mapstructure:"title,omitempty"`
+	Extensions       []Extension    `mapstructure:"-"`
 	AdditionalFields map[string]any `mapstructure:",remain"`
+}
+
+var linkExtensions = newExtensionRegistry()
+
+func RegisterLinkExtension(pattern *regexp.Regexp, provider ExtensionProvider) {
+	linkExtensions.register(pattern, provider)
+}
+
+func GetLinkExtension(uri string) Extension {
+	return linkExtensions.get(uri)
+}
+
+func EncodeLinks(links []*Link) ([]map[string]any, []string, error) {
+	extensionUris := []string{}
+	linksData := make([]map[string]any, len(links))
+	for i, link := range links {
+		linkMap := map[string]any{}
+		decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+			Result: &linkMap,
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := decoder.Decode(link); err != nil {
+			return nil, nil, err
+		}
+
+		// remove if https://github.com/mitchellh/mapstructure/issues/279 is fixed
+		delete(linkMap, "AdditionalFields")
+		for k, v := range link.AdditionalFields {
+			linkMap[k] = v
+		}
+
+		for _, extension := range link.Extensions {
+			extensionUris = append(extensionUris, extension.URI())
+			if err := extension.Encode(linkMap); err != nil {
+				return nil, nil, err
+			}
+		}
+		linksData[i] = linkMap
+	}
+	return linksData, extensionUris, nil
 }
 
 var (


### PR DESCRIPTION
This adds support for `auth:schemes` in catalogs and collections and for `auth:refs` in links and assets as described in https://github.com/stac-extensions/authentication.