### PR TITLE
Update mapstructure

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -3,7 +3,7 @@ package stac
 import (
 	"regexp"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 type Asset struct {

--- a/catalog.go
+++ b/catalog.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 type Catalog struct {

--- a/catalog_test.go
+++ b/catalog_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/planetlabs/go-stac"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/collection.go
+++ b/collection.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 type Collection struct {

--- a/extension.go
+++ b/extension.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"sync"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 type Extension interface {

--- a/extensions/auth/auth.go
+++ b/extensions/auth/auth.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/planetlabs/go-stac"
 )
 

--- a/extensions/itemassets/itemassets.go
+++ b/extensions/itemassets/itemassets.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/planetlabs/go-stac"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/dlclark/regexp2 v1.11.4
 	github.com/go-logr/logr v1.4.2
 	github.com/go-logr/zapr v1.3.0
+	github.com/go-viper/mapstructure/v2 v2.1.0
 	github.com/google/go-github/v51 v51.0.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
-	github.com/mitchellh/mapstructure v1.5.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/schollz/progressbar/v3 v3.14.6
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,8 @@ github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
 github.com/go-logr/zapr v1.3.0/go.mod h1:YKepepNBd1u/oyhd/yQmtjVXmm9uML4IXUgMOwR8/Gg=
+github.com/go-viper/mapstructure/v2 v2.1.0 h1:gHnMa2Y/pIxElCH2GlZZ1lZSsn6XMtufpGyP1XxdC/w=
+github.com/go-viper/mapstructure/v2 v2.1.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
@@ -42,8 +44,6 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db h1:62I3jR2EmQ4l5rM/4FEfDWcRD+abF5XlKShorW5LRoQ=
 github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db/go.mod h1:l0dey0ia/Uv7NcFFVbCLtqEBQbrT4OCwCSKTEv6enCw=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/item.go
+++ b/item.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 var coreItemProperties = map[string]bool{

--- a/link.go
+++ b/link.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"regexp"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 type Link struct {
@@ -41,12 +41,6 @@ func EncodeLinks(links []*Link) ([]map[string]any, []string, error) {
 			return nil, nil, err
 		}
 
-		// remove if https://github.com/mitchellh/mapstructure/issues/279 is fixed
-		delete(linkMap, "AdditionalFields")
-		for k, v := range link.AdditionalFields {
-			linkMap[k] = v
-		}
-
 		for _, extension := range link.Extensions {
 			extensionUris = append(extensionUris, extension.URI())
 			if err := extension.Encode(linkMap); err != nil {
@@ -67,11 +61,6 @@ func (link *Link) MarshalJSON() ([]byte, error) {
 	m := map[string]any{}
 	if err := mapstructure.Decode(link, &m); err != nil {
 		return nil, err
-	}
-	// remove if https://github.com/mitchellh/mapstructure/issues/279 is fixed
-	delete(m, "AdditionalFields")
-	for k, v := range link.AdditionalFields {
-		m[k] = v
 	}
 	return json.Marshal(m)
 }


### PR DESCRIPTION
The [original project](https://github.com/mitchellh/mapstructure) has been [archived](https://gist.github.com/mitchellh/90029601268e59a29e64e55bab1c5bdc).  This makes use of the "blessed fork": https://github.com/go-viper/mapstructure.