### PR TITLE
Support for unmarshalling custom geometry types

### DIFF
--- a/item_test.go
+++ b/item_test.go
@@ -63,3 +63,97 @@ func TestItemMarshal(t *testing.T) {
 
 	assert.JSONEq(t, expected, string(data))
 }
+
+func TestItemUnmarshal(t *testing.T) {
+	data := `{
+		"type": "Feature",
+		"stac_version": "1.0.0",
+		"id": "item-id",
+		"geometry": {
+			"type": "Point",
+			"coordinates": [1, 2]
+		},
+		"properties": {
+			"test": "value"
+		},
+		"links": [
+			{
+				"rel": "self",
+				"href": "https://example.com/stac/item-id"
+			}
+		],
+		"assets": {
+			"thumbnail": {
+				"title": "Thumbnail",
+				"href": "https://example.com/stac/item-id/thumb.png",
+				"type": "image/png"
+			}
+		}
+	}`
+
+	item := &stac.Item{}
+	require.NoError(t, json.Unmarshal([]byte(data), item))
+
+	assert.Equal(t, "item-id", item.Id)
+
+	require.NotNil(t, item.Geometry)
+
+	g, ok := item.Geometry.(map[string]any)
+	require.True(t, ok)
+	geometryType, ok := g["type"].(string)
+	require.True(t, ok)
+	assert.Equal(t, "Point", geometryType)
+}
+
+type TestGeometry struct {
+	data []byte
+}
+
+func (g *TestGeometry) UnmarshalJSON(data []byte) error {
+	g.data = data
+	return nil
+}
+
+func TestGeometryUnmarshal(t *testing.T) {
+	original := &TestGeometry{}
+	stac.GeometryUnmarshaler(original)
+	defer stac.GeometryUnmarshaler(nil)
+
+	data := `{
+		"type": "Feature",
+		"stac_version": "1.0.0",
+		"id": "item-id",
+		"geometry": {
+			"type": "Point",
+			"coordinates": [1, 2]
+		},
+		"properties": {
+			"test": "value"
+		},
+		"links": [
+			{
+				"rel": "self",
+				"href": "https://example.com/stac/item-id"
+			}
+		],
+		"assets": {
+			"thumbnail": {
+				"title": "Thumbnail",
+				"href": "https://example.com/stac/item-id/thumb.png",
+				"type": "image/png"
+			}
+		}
+	}`
+
+	item := &stac.Item{}
+	require.NoError(t, json.Unmarshal([]byte(data), item))
+
+	assert.Equal(t, "item-id", item.Id)
+
+	assert.Nil(t, original.data)
+	require.NotNil(t, item.Geometry)
+
+	g, ok := item.Geometry.(*TestGeometry)
+	require.True(t, ok)
+	assert.NotNil(t, g.data)
+}


### PR DESCRIPTION
Calling the `stac.GeometryUnmarshaller()` function registers a custom geometry type to be used when deserializing items.