### PR TITLE
Avoid URL-component encoding for file paths

### DIFF
--- a/internal/normurl/normurl.go
+++ b/internal/normurl/normurl.go
@@ -53,6 +53,9 @@ func (l *Locator) MarshalJSON() ([]byte, error) {
 }
 
 func (l *Locator) String() string {
+	if l.file {
+		return l.url.Path
+	}
 	return l.url.String()
 }
 

--- a/internal/normurl/normurl_test.go
+++ b/internal/normurl/normurl_test.go
@@ -183,6 +183,21 @@ func TestResolve(t *testing.T) {
 			expected: "/bam",
 		},
 		{
+			base:     "/base/directory/",
+			input:    "./path/with spaces/some resource",
+			expected: "/base/directory/path/with spaces/some resource",
+		},
+		{
+			base:     "/base/with space/",
+			input:    "./path/with spaces/some resource",
+			expected: "/base/with space/path/with spaces/some resource",
+		},
+		{
+			base:     "/base/with space/",
+			input:    "./path/to/resource",
+			expected: "/base/with space/path/to/resource",
+		},
+		{
 			base:     "/foo/bar/",
 			input:    "https://example.com/bam",
 			expected: "https://example.com/bam",


### PR DESCRIPTION
Previously, the validator used URL encoding to resolve file paths. This means that a space in a path would be converted to `%20`, for example. This change makes it so the validator uses file paths without URL encoding instead.